### PR TITLE
Add initial support for ATA over Ethernet (AoE) protocol

### DIFF
--- a/dpkt/aoe.py
+++ b/dpkt/aoe.py
@@ -1,0 +1,70 @@
+"""ATA over Ethernet Protocol."""
+
+import struct
+
+
+import dpkt
+
+
+class AOE(dpkt.Packet):
+    __hdr__ = (
+        ('ver_fl', 'B', 0x10),
+        ('err', 'B', 0),
+        ('maj', 'H', 0),
+        ('min', 'B', 0),
+        ('cmd', 'B', 0),
+        ('tag', 'I', 0),
+        )
+    _cmdsw = {}
+    
+    def _get_ver(self): return self.ver_fl >> 4
+    def _set_ver(self, ver): self.ver_fl = (ver << 4) | (self.ver_fl & 0xf)
+    ver = property(_get_ver, _set_ver)
+
+    def _get_fl(self): return self.ver_fl & 0xf
+    def _set_fl(self, fl): self.ver_fl = (self.ver_fl & 0xf0) | fl
+    fl = property(_get_fl, _set_fl)
+
+    def set_cmd(cls, cmd, pktclass):
+        cls._cmdsw[cmd] = pktclass
+    set_cmd = classmethod(set_cmd)
+
+    def get_cmd(cls, cmd):
+        return cls._cmdsw[cmd]
+    get_cmd = classmethod(get_cmd)
+
+    def unpack(self, buf):
+        dpkt.Packet.unpack(self, buf)
+        try:
+            self.data = self._cmdsw[self.cmd](self.data)
+            setattr(self, self.data.__class__.__name__.lower(), self.data)
+        except (KeyError, struct.error, dpkt.UnpackError):
+            pass
+
+    def pack_hdr(self):
+        try:
+            return dpkt.Packet.pack_hdr(self)
+        except struct.error, e:
+            raise dpkt.PackError(str(e))
+
+
+AOE_CMD_ATA = 0
+AOE_CMD_CFG = 1
+AOE_FLAG_RSP = 1 << 3
+
+
+def __load_cmds():
+    prefix = 'AOE_CMD_'
+    g = globals()
+    for k, v in g.iteritems():
+        if k.startswith(prefix):
+            name = 'aoe' + k[len(prefix):].lower()
+            try:
+                mod = __import__(name, g)
+            except ImportError:
+                continue
+            AOE.set_cmd(v, getattr(mod, name.upper()))
+
+
+if not AOE._cmdsw:
+    __load_cmds()

--- a/dpkt/aoeata.py
+++ b/dpkt/aoeata.py
@@ -1,0 +1,34 @@
+'''ATA over Ethernet ATA command'''
+
+import dpkt, aoe
+
+ATA_DEVICE_IDENTIFY = 0xec
+
+class AOEATA(dpkt.Packet):
+    __hdr__ = (
+        ('aflags', 'B', 0),
+        ('errfeat', 'B', 0),
+	('scnt', 'B', 0),
+	('cmdstat', 'B', ATA_DEVICE_IDENTIFY),
+	('lba0', 'B', 0),
+	('lba1', 'B', 0),
+	('lba2', 'B', 0),
+	('lba3', 'B', 0),
+	('lba4', 'B', 0),
+	('lba5', 'B', 0),
+	('res', 'H', 0),
+    )
+
+    # XXX: in unpack, switch on ATA command like icmp does on type
+
+
+if __name__ == '__main__':
+    import unittest
+
+    class AOEATATestCase(unittest.TestCase):
+        def test_AOEATA(self):
+            s = '\x03\x0a\x6b\x19\x00\x00\x00\x00\x45\x00\x00\x28\x94\x1f\x00\x00\xe3\x06\x99\xb4\x23\x2b\x24\x00\xde\x8e\x84\x42\xab\xd1\x00\x50\x00\x35\xe1\x29\x20\xd9\x00\x00\x00\x22\x9b\xf0\xe2\x04\x65\x6b'
+            aoeata = AOEATA(s)
+            self.failUnless(str(aoeata) == s)
+
+    unittest.main()

--- a/dpkt/aoecfg.py
+++ b/dpkt/aoecfg.py
@@ -1,0 +1,24 @@
+'''ATA over Ethernet ATA command'''
+
+import dpkt
+
+class AOECFG(dpkt.Packet):
+    __hdr__ = (
+        ('bufcnt', 'H', 0),
+        ('fwver', 'H', 0),
+	('scnt', 'B', 0),
+	('aoeccmd', 'B', 0),
+	('cslen', 'H', 0),
+    )
+
+
+if __name__ == '__main__':
+    import unittest
+
+    class AOECFGTestCase(unittest.TestCase):
+        def test_AOECFG(self):
+            s = '\x01\x02\x03\x04\x05\x06\x11\x12\x13\x14\x15\x16\x88\xa2\x10\x00\x00\x01\x02\x01\x80\x00\x00\x00\x12\x34\x00\x00\x00\x00\x04\x00' + '\0xed' * 1024
+            aoecfg = AOECFG(s[14+10:])
+            self.failUnless(aoecfg.bufcnt == 0x1234)
+
+    unittest.main()

--- a/dpkt/ethernet.py
+++ b/dpkt/ethernet.py
@@ -19,6 +19,7 @@ ETH_MIN		= (ETH_LEN_MIN - ETH_HDR_LEN - ETH_CRC_LEN)
 ETH_TYPE_PUP	= 0x0200		# PUP protocol
 ETH_TYPE_IP	= 0x0800		# IP protocol
 ETH_TYPE_ARP	= 0x0806		# address resolution protocol
+ETH_TYPE_AOE	= 0x88a2		# AoE protocol
 ETH_TYPE_CDP	= 0x2000		# Cisco Discovery Protocol
 ETH_TYPE_DTP	= 0x2004		# Cisco Dynamic Trunking Protocol
 ETH_TYPE_REVARP	= 0x8035		# reverse addr resolution protocol


### PR DESCRIPTION
AoE is a protocol used for ethernet-only block storage.  You can create a VLAN for an array of disks, put a couple of ports on a server on that VLAN, and use the disks over an ethernet switch.  Using the protocol doesn't require as much configuration or packet-level overhead as alternatives, and targets can be very inexpensive devices.

The AoE protocol is not supported by upstream dpkt, but these patches add support.  Feedback is encouraged.
