### PR TITLE
deprecated and duration decorators

### DIFF
--- a/dpkt/aoe.py
+++ b/dpkt/aoe.py
@@ -3,7 +3,7 @@
 
 import struct
 import dpkt
-from decorators import deprecated_method_decorator
+from decorators import deprecated
 
 
 class AOE(dpkt.Packet):
@@ -53,16 +53,16 @@ class AOE(dpkt.Packet):
 
     # Deprecated methods, will be removed in the future
     # =================================================
-    @deprecated_method_decorator
+    @deprecated
     def _get_ver(self): return self.ver
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_ver(self, ver): self.ver = ver
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_fl(self): return self.fl
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_fl(self, fl): self.fl = fl
     # =================================================
 

--- a/dpkt/bgp.py
+++ b/dpkt/bgp.py
@@ -5,7 +5,7 @@
 import struct
 import socket
 import dpkt
-from decorators import deprecated_method_decorator
+from decorators import deprecated
 
 
 # Border Gateway Protocol 4 - RFC 4271
@@ -293,35 +293,35 @@ class BGP(dpkt.Packet):
 
             # Deprecated methods, will be removed in the future
             # ======================================================
-            @deprecated_method_decorator
+            @deprecated
             def _get_o(self):
                 return self.optional
 
-            @deprecated_method_decorator
+            @deprecated
             def _set_o(self, o):
                 self.optional = o
 
-            @deprecated_method_decorator
+            @deprecated
             def _get_t(self):
                 return self.transitive
 
-            @deprecated_method_decorator
+            @deprecated
             def _set_t(self, t):
                 self.transitive = t
 
-            @deprecated_method_decorator
+            @deprecated
             def _get_p(self):
                 return self.partial
 
-            @deprecated_method_decorator
+            @deprecated
             def _set_p(self, p):
                 self.partial = p
 
-            @deprecated_method_decorator
+            @deprecated
             def _get_e(self):
                 return self.extended_length
 
-            @deprecated_method_decorator
+            @deprecated
             def _set_e(self, e):
                 self.extended_length = e
 

--- a/dpkt/decorators.py
+++ b/dpkt/decorators.py
@@ -1,21 +1,52 @@
 # -*- coding: utf-8 -*-
 import warnings
+from timeit import Timer
+from test import pystone
+from time import sleep
+
+
+def decorator_with_args(decorator_to_enhance):
+    """
+    This is decorator for decorator. It allows any decorator to get additional arguments
+    """
+    def decorator_maker(*args, **kwargs):
+        def decorator_wrapper(func):
+            return decorator_to_enhance(func, *args, **kwargs)
+        return decorator_wrapper
+    return decorator_maker
 
 
 def deprecated(deprecated_method):
-    def wrapper(*args, **kwargs):
+    def _deprecated(*args, **kwargs):
         # Print only the first occurrence of the DeprecationWarning, regardless of location
         warnings.simplefilter('once', DeprecationWarning)
         # Display the deprecation warning message
         warnings.warn("Call to deprecated method %s" % deprecated_method.__name__,
                       category=DeprecationWarning, stacklevel=2)
         return deprecated_method(*args, **kwargs)  # actually call the method
-    return wrapper
+
+    return _deprecated
+
+
+@decorator_with_args
+def duration(function, repeat=10000):
+    def _duration(*args, **kwargs):
+        time = 0
+        try:
+            time = Timer(lambda: function(*args, **kwargs)).timeit(repeat)
+        finally:
+            benchtime, pystones = pystone.pystones()
+            kstones = (pystones * time) / 1000
+            print '%s : time = %f kstones = %f' % (function.__name__, time, kstones)
+        return function(*args, **kwargs)
+
+    return _duration
 
 
 class TestDeprecatedDecorator(object):
     @deprecated
-    def deprecated_decorator(self): return
+    def deprecated_decorator(self):
+        return
 
     def test_deprecated_decorator(self):
         import sys
@@ -26,13 +57,34 @@ class TestDeprecatedDecorator(object):
             out = StringIO()
             sys.stderr = out
             self.deprecated_decorator()
-            assert('DeprecationWarning: Call to deprecated method deprecated_decorator' in out.getvalue())
+            assert ('DeprecationWarning: Call to deprecated method deprecated_decorator' in out.getvalue())
             # 'in' because message contains the filename, line, etc
         finally:
             sys.stderr = saved_stderr
 
 
+class TestDurationDecorator(object):
+    @duration(1)
+    def duration_decorator(self):
+        sleep(0.05)
+        return
+
+    def test_duration_decorator(self):
+        import sys
+        from StringIO import StringIO
+
+        saved_stdout = sys.stdout
+        try:
+            out = StringIO()
+            sys.stdout = out
+            self.duration_decorator()
+            assert ('duration_decorator : ' in out.getvalue())
+        finally:
+            sys.stdout = saved_stdout
+
 if __name__ == '__main__':
     a = TestDeprecatedDecorator()
     a.test_deprecated_decorator()
+    a = TestDurationDecorator()
+    a.test_duration_decorator()
     print 'Tests Successful...'

--- a/dpkt/decorators.py
+++ b/dpkt/decorators.py
@@ -2,7 +2,7 @@
 import warnings
 
 
-def deprecated_method_decorator(deprecated_method):
+def deprecated(deprecated_method):
     def wrapper(*args, **kwargs):
         # Print only the first occurrence of the DeprecationWarning, regardless of location
         warnings.simplefilter('once', DeprecationWarning)
@@ -10,15 +10,14 @@ def deprecated_method_decorator(deprecated_method):
         warnings.warn("Call to deprecated method %s" % deprecated_method.__name__,
                       category=DeprecationWarning, stacklevel=2)
         return deprecated_method(*args, **kwargs)  # actually call the method
-
     return wrapper
 
 
-class TestDeprecatedMethodDecorator:
-    @deprecated_method_decorator
-    def deprecated_method_decorator(self): return
+class TestDeprecatedDecorator(object):
+    @deprecated
+    def deprecated_decorator(self): return
 
-    def test_deprecated_method_decorator(self):
+    def test_deprecated_decorator(self):
         import sys
         from StringIO import StringIO
 
@@ -26,14 +25,14 @@ class TestDeprecatedMethodDecorator:
         try:
             out = StringIO()
             sys.stderr = out
-            self.deprecated_method_decorator()
-            assert('DeprecationWarning: Call to deprecated method deprecated_method_decorator' in out.getvalue())
+            self.deprecated_decorator()
+            assert('DeprecationWarning: Call to deprecated method deprecated_decorator' in out.getvalue())
             # 'in' because message contains the filename, line, etc
         finally:
             sys.stderr = saved_stderr
 
 
 if __name__ == '__main__':
-    a = TestDeprecatedMethodDecorator()
-    a.test_deprecated_method_decorator()
+    a = TestDeprecatedDecorator()
+    a.test_deprecated_decorator()
     print 'Tests Successful...'

--- a/dpkt/diameter.py
+++ b/dpkt/diameter.py
@@ -4,7 +4,7 @@
 
 import struct
 import dpkt
-from decorators import deprecated_method_decorator
+from decorators import deprecated
 
 # Diameter Base Protocol - RFC 3588
 # http://tools.ietf.org/html/rfc3588
@@ -64,28 +64,28 @@ class Diameter(dpkt.Packet):
 
     # Deprecated methods, will be removed in the future
     # ======================================================
-    @deprecated_method_decorator
+    @deprecated
     def _get_r(self): return self.request_flag
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_r(self, r): self.request_flag = r
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_p(self): return self.proxiable_flag
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_p(self, p): self.proxiable_flag = p
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_e(self): return self.error_flag
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_e(self, e): self.error_flag = e
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_t(self): return self.request_flag
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_t(self, t): self.request_flag = t
 
     # ======================================================
@@ -148,27 +148,27 @@ class AVP(dpkt.Packet):
 
     # Deprecated methods, will be removed in the future
     # ======================================================
-    @deprecated_method_decorator
+    @deprecated
     def _get_v(self):
         return self.vendor_flag
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_v(self, v):
         self.vendor_flag = v
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_m(self):
         return self.mandatory_flag
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_m(self, m):
         self.mandatory_flag = m
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_p(self):
         return self.protected_flag
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_p(self, p):
         self.protected_flag = p
 

--- a/dpkt/dns.py
+++ b/dpkt/dns.py
@@ -4,7 +4,7 @@
 
 import struct
 import dpkt
-from decorators import deprecated_method_decorator
+from decorators import deprecated
 
 DNS_Q = 0
 DNS_R = 1
@@ -190,59 +190,59 @@ class DNS(dpkt.Packet):
 
     # Deprecated methods, will be removed in the future
     # ======================================================
-    @deprecated_method_decorator
+    @deprecated
     def get_qr(self):
         return self.qr
 
-    @deprecated_method_decorator
+    @deprecated
     def set_qr(self, v):
         self.qr = v
 
-    @deprecated_method_decorator
+    @deprecated
     def get_opcode(self):
         return self.opcode
 
-    @deprecated_method_decorator
+    @deprecated
     def set_opcode(self, v):
         self.opcode = v
 
-    @deprecated_method_decorator
+    @deprecated
     def get_aa(self):
         return self.aa
 
-    @deprecated_method_decorator
+    @deprecated
     def set_aa(self, v):
         self.aa = v
 
-    @deprecated_method_decorator
+    @deprecated
     def get_rd(self):
         return self.rd
 
-    @deprecated_method_decorator
+    @deprecated
     def set_rd(self, v):
         self.rd = v
 
-    @deprecated_method_decorator
+    @deprecated
     def get_ra(self):
         return self.ra
 
-    @deprecated_method_decorator
+    @deprecated
     def set_ra(self, v):
         self.ra = v
 
-    @deprecated_method_decorator
+    @deprecated
     def get_zero(self):
         return self.zero
 
-    @deprecated_method_decorator
+    @deprecated
     def set_zero(self, v):
         self.zero = v
 
-    @deprecated_method_decorator
+    @deprecated
     def get_rcode(self):
         return self.rcode
 
-    @deprecated_method_decorator
+    @deprecated
     def set_rcode(self, v):
         self.rcode = v
 

--- a/dpkt/gre.py
+++ b/dpkt/gre.py
@@ -4,7 +4,7 @@
 
 import struct
 import dpkt
-from decorators import deprecated_method_decorator
+from decorators import deprecated
 
 GRE_CP = 0x8000  # Checksum Present
 GRE_RP = 0x4000  # Routing Present
@@ -45,16 +45,16 @@ class GRE(dpkt.Packet):
 
     # Deprecated methods, will be removed in the future
     # =================================================
-    @deprecated_method_decorator
+    @deprecated
     def get_v(self): return self.v
 
-    @deprecated_method_decorator
+    @deprecated
     def set_v(self, v): self.v = v
 
-    @deprecated_method_decorator
+    @deprecated
     def get_recur(self): return self.recur
 
-    @deprecated_method_decorator
+    @deprecated
     def set_recur(self, v): self.recur = v
     # =================================================
 

--- a/dpkt/ieee80211.py
+++ b/dpkt/ieee80211.py
@@ -5,7 +5,7 @@
 import socket
 import struct
 import dpkt
-from decorators import deprecated_method_decorator
+from decorators import deprecated
 
 # Frame Types
 MGMT_TYPE = 0
@@ -210,70 +210,70 @@ class IEEE80211(dpkt.Packet):
 
     # Deprecated methods, will be removed in the future
     # =================================================
-    @deprecated_method_decorator
+    @deprecated
     def _get_version(self): return self.version
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_version(self, val): self.version = val
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_type(self): return self.type
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_type(self, val): self.type = val
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_subtype(self): return self.subtype
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_subtype(self, val): self.subtype = val
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_to_ds(self): return self.to_ds
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_to_ds(self, val): self.to_ds = val
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_from_ds(self): return self.from_ds
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_from_ds(self, val): self.from_ds = val
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_more_frag(self): return self.more_frag
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_more_frag(self, val): self.more_frag = val
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_retry(self): return self.retry
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_retry(self, val): self.retry = val
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_pwr_mgt(self): return self.pwr_mgt
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_pwr_mgt(self, val): self.pwr_mgt = val
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_more_data(self): return self.more_data
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_more_data(self, val): self.more_data = val
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_wep(self): return self.wep
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_wep(self, val): self.wep = val
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_order(self): return self.order
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_order(self, val): self.order = val
     # =================================================
 
@@ -479,28 +479,28 @@ class IEEE80211(dpkt.Packet):
 
         # Deprecated methods, will be removed in the future
         # =================================================
-        @deprecated_method_decorator
+        @deprecated
         def _get_compressed(self): return self.compressed
 
-        @deprecated_method_decorator
+        @deprecated
         def _set_compressed(self, val): self.compressed = val
 
-        @deprecated_method_decorator
+        @deprecated
         def _get_ack_policy(self): return self.ack_policy
 
-        @deprecated_method_decorator
+        @deprecated
         def _set_ack_policy(self, val): self.ack_policy = val
 
-        @deprecated_method_decorator
+        @deprecated
         def _get_multi_tid(self): return self.multi_tid
 
-        @deprecated_method_decorator
+        @deprecated
         def _set_multi_tid(self, val): self.multi_tid = val
 
-        @deprecated_method_decorator
+        @deprecated
         def _get_tid(self): return self.tid
 
-        @deprecated_method_decorator
+        @deprecated
         def _set_tid(self, val): self.tid = val
         # =================================================
 

--- a/dpkt/ip.py
+++ b/dpkt/ip.py
@@ -3,7 +3,7 @@
 """Internet Protocol."""
 
 import dpkt
-from decorators import deprecated_method_decorator
+from decorators import deprecated
 
 
 class IP(dpkt.Packet):
@@ -40,19 +40,19 @@ class IP(dpkt.Packet):
 
     # Deprecated methods, will be removed in the future
     # =================================================
-    @deprecated_method_decorator
+    @deprecated
     def _get_v(self):
         return self.v
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_v(self, v):
         self.v = v
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_hl(self):
         return self.hl
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_hl(self, hl):
         self.hl = hl
 

--- a/dpkt/ip6.py
+++ b/dpkt/ip6.py
@@ -3,7 +3,7 @@
 """Internet Protocol, version 6."""
 
 import dpkt
-from decorators import deprecated_method_decorator
+from decorators import deprecated
 
 
 class IP6(dpkt.Packet):
@@ -48,27 +48,27 @@ class IP6(dpkt.Packet):
 
     # Deprecated methods, will be removed in the future
     # =================================================
-    @deprecated_method_decorator
+    @deprecated
     def _get_v(self):
         return self.v
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_v(self, v):
         self.v = v
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_fc(self):
         return self.fc
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_fc(self, v):
         self.rc = v
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_flow(self):
         return self.flow
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_flow(self, v):
         self.flow = v
 
@@ -266,16 +266,16 @@ class IP6FragmentHeader(IP6ExtensionHeader):
 
     # Deprecated methods, will be removed in the future
     # =================================================
-    @deprecated_method_decorator
+    @deprecated
     def _get_frag_off(self): return self.flag_off
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_frag_off(self, v): self.flag_off = v
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_m_flag(self): return self.m_flag
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_m_flag(self, v): self.m_flag = v
 
     # =================================================

--- a/dpkt/ntp.py
+++ b/dpkt/ntp.py
@@ -3,7 +3,7 @@
 """Network Time Protocol."""
 
 import dpkt
-from decorators import deprecated_method_decorator
+from decorators import deprecated
 
 # NTP v4
 
@@ -65,22 +65,22 @@ class NTP(dpkt.Packet):
 
     # Deprecated methods, will be removed in the future
     # =================================================
-    @deprecated_method_decorator
+    @deprecated
     def _get_v(self): return self.v
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_v(self, v): self.v = v
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_li(self): return self.li
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_li(self, li): self.li = li
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_mode(self): return self.mode
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_mode(self, mode): self.mode = mode
     # =================================================
 

--- a/dpkt/pim.py
+++ b/dpkt/pim.py
@@ -3,7 +3,7 @@
 """Protocol Independent Multicast."""
 
 import dpkt
-from decorators import deprecated_method_decorator
+from decorators import deprecated
 
 
 class PIM(dpkt.Packet):
@@ -27,16 +27,16 @@ class PIM(dpkt.Packet):
 
     # Deprecated methods, will be removed in the future
     # =================================================
-    @deprecated_method_decorator
+    @deprecated
     def _get_v(self): return self.v
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_v(self, v): self.v = v
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_type(self): return self.type
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_type(self, type): self.type = type
     # =================================================
 

--- a/dpkt/pppoe.py
+++ b/dpkt/pppoe.py
@@ -4,7 +4,7 @@
 
 import dpkt
 import ppp
-from decorators import deprecated_method_decorator
+from decorators import deprecated
 
 # RFC 2516 codes
 PPPoE_PADI = 0x09
@@ -37,16 +37,16 @@ class PPPoE(dpkt.Packet):
 
     # Deprecated methods, will be removed in the future
     # =================================================
-    @deprecated_method_decorator
+    @deprecated
     def _get_v(self): return self.v
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_v(self, v): self.v = v
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_type(self): return self.type
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_type(self, t): self.type = t
     # =================================================
 

--- a/dpkt/radiotap.py
+++ b/dpkt/radiotap.py
@@ -4,7 +4,7 @@
 import dpkt
 import ieee80211
 import socket
-from decorators import deprecated_method_decorator
+from decorators import deprecated
 
 # Ref: http://www.radiotap.org
 # Fields Ref: http://www.radiotap.org/defined-fields/all
@@ -223,139 +223,139 @@ class Radiotap(dpkt.Packet):
 
     # Deprecated methods, will be removed in the future
     # =================================================
-    @deprecated_method_decorator
+    @deprecated
     def _get_tsft_present(self):
         return self.tsft_present
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_tsft_present(self, val):
         self.tsft_present = val
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_flags_present(self):
         return self.flags_present
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_flags_present(self, val):
         self.flags_present = val
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_rate_present(self):
         return self.rate_present
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_rate_present(self, val):
         self.rate_present = val
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_channel_present(self):
         return self.channel_present
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_channel_present(self, val):
         self.channel_present = val
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_fhss_present(self):
         return self.fhss_present
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_fhss_present(self, val):
         self.fhss_present = val
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_ant_sig_present(self):
         return self.ant_sig_present
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_ant_sig_present(self, val):
         self.ant_sig_present = val
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_ant_noise_present(self):
         return self.ant_noise_present
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_ant_noise_present(self, val):
         self.ant_noise_present = val
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_lock_qual_present(self):
         return self.lock_qual_present
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_lock_qual_present(self, val):
         self.lock_qual_present = val
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_tx_attn_present(self):
         return self.tx_attn_present
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_tx_attn_present(self, val):
         self.tx_attn_present = val
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_db_tx_attn_present(self):
         return self.db_tx_attn_present
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_db_tx_attn_present(self, val):
         self.db_tx_attn_present = val
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_dbm_power_present(self):
         return self.dbm_tx_power_present
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_dbm_power_present(self, val):
         self.dbm_tx_power_present = val
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_ant_present(self):
         return self.ant_present
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_ant_present(self, val):
         self.ant_present = val
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_db_ant_sig_present(self):
         return self.db_ant_sig_present
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_db_ant_sig_present(self, val):
         self.db_ant_sig_present = val
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_db_ant_noise_present(self):
         return self.db_ant_noise_present
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_db_ant_noise_present(self, val):
         self.db_ant_noise_present = val
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_rx_flags_present(self):
         return self.rx_flags_present
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_rx_flags_present(self, val):
         self.rx_flags_present = val
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_chanplus_present(self):
         return self.chanplus_present
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_chanplus_present(self, val):
         self.chanplus_present = val
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_ext_present(self):
         return self.ext_present
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_ext_present(self, val):
         self.ext_present = val
 
@@ -441,10 +441,10 @@ class Radiotap(dpkt.Packet):
 
         # Deprecated methods, will be removed in the future
         # =================================================
-        @deprecated_method_decorator
+        @deprecated
         def _get_fcs_present(self): return self.fcs
 
-        @deprecated_method_decorator
+        @deprecated
         def _set_fcs_present(self, v): self.fcs = v
 
         # =================================================

--- a/dpkt/rtp.py
+++ b/dpkt/rtp.py
@@ -3,7 +3,7 @@
 """Real-Time Transport Protocol"""
 
 from dpkt import Packet
-from decorators import deprecated_method_decorator
+from decorators import deprecated
 
 # version 1100 0000 0000 0000 ! 0xC000  14
 # p       0010 0000 0000 0000 ! 0x2000  13
@@ -77,40 +77,40 @@ class RTP(Packet):
 
     # Deprecated methods, will be removed in the future
     # =================================================
-    @deprecated_method_decorator
+    @deprecated
     def _get_version(self): return self.version
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_version(self, ver): self.version = ver
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_p(self): return self.p
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_p(self, p): self.p = p
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_x(self): return self.x
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_x(self, x): self.x = x
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_cc(self): return self.cc
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_cc(self, cc): self.cc = cc
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_m(self): return self.m
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_m(self, m): self.m = m
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_pt(self): return self.pt
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_pt(self, pt): self.pt = pt
     # =================================================
 

--- a/dpkt/ssl.py
+++ b/dpkt/ssl.py
@@ -136,14 +136,12 @@ _SIZE_FORMATS = ['!B', '!H', '!I', '!I']
 
 
 def parse_variable_array(buf, lenbytes):
-
     """
     Parse an array described using the 'Type name<x..y>' syntax from the spec
     Read a length at the start of buf, and returns that many bytes
     after, in a tuple with the TOTAL bytes consumed (including the size). This
     does not check that the array is the right length for any given datatype.
     """
-
     # first have to figure out how to parse length
     assert lenbytes <= 4  # pretty sure 4 is impossible, too
     size_format = _SIZE_FORMATS[lenbytes - 1]
@@ -363,7 +361,6 @@ class SSLFactory(object):
 
 
 def tls_multi_factory(buf):
-
     """
     Attempt to parse one or more TLSRecord's out of buf
 
@@ -378,7 +375,6 @@ def tls_multi_factory(buf):
 
     Raises SSL3Exception.
     """
-
     i, n = 0, len(buf)
     msgs = []
     while i < n:

--- a/dpkt/ssl.py
+++ b/dpkt/ssl.py
@@ -498,9 +498,7 @@ class TestClientHello(object):
         cls.p = TLSHandshake(cls.data)
 
     def test_client_hello_constructed(self):
-
         """Make sure the correct class was constructed"""
-
         # print self.p
         assert (isinstance(self.p.data, TLSClientHello) == True)
 

--- a/dpkt/tcp.py
+++ b/dpkt/tcp.py
@@ -3,7 +3,7 @@
 """Transmission Control Protocol."""
 
 import dpkt
-from decorators import deprecated_method_decorator
+from decorators import deprecated
 
 # TCP control flags
 TH_FIN = 0x01  # end of data
@@ -41,10 +41,10 @@ class TCP(dpkt.Packet):
 
     # Deprecated methods, will be removed in the future
     # =================================================
-    @deprecated_method_decorator
+    @deprecated
     def _get_off(self): return self.off
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_off(self, off): self.off = off
     # =================================================
 

--- a/dpkt/vrrp.py
+++ b/dpkt/vrrp.py
@@ -3,7 +3,7 @@
 """Virtual Router Redundancy Protocol."""
 
 import dpkt
-from decorators import deprecated_method_decorator
+from decorators import deprecated
 
 
 class VRRP(dpkt.Packet):
@@ -37,16 +37,16 @@ class VRRP(dpkt.Packet):
 
     # Deprecated methods, will be removed in the future
     # =================================================
-    @deprecated_method_decorator
+    @deprecated
     def _get_v(self): return self.v
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_v(self, v): self.v = v
 
-    @deprecated_method_decorator
+    @deprecated
     def _get_type(self): return self.type
 
-    @deprecated_method_decorator
+    @deprecated
     def _set_type(self, v): self.type = v
     # =================================================
 


### PR DESCRIPTION
deprecated_method_decorator renamed as deprecated.
duration decorator - now it is available to measure execution time in pystones