### PR TITLE
add missing conversions to str in __str__()

### DIFF
--- a/dpkt/ip.py
+++ b/dpkt/ip.py
@@ -63,7 +63,7 @@ class IP(dpkt.Packet):
 
     def __str__(self):
         if self.sum == 0:
-            self.sum = dpkt.in_cksum(self.pack_hdr() + self.opts)
+            self.sum = dpkt.in_cksum(self.pack_hdr() + str(self.opts))
             if (self.p == 6 or self.p == 17) and (self.off & (IP_MF | IP_OFFMASK)) == 0 and \
                     isinstance(self.data, dpkt.Packet) and self.data.sum == 0:
                 # Set zeroed TCP and UDP checksums for non-fragments.
@@ -76,7 +76,7 @@ class IP(dpkt.Packet):
                 if self.p == 17 and self.data.sum == 0:
                     self.data.sum = 0xffff  # RFC 768
                     # XXX - skip transports which don't need the pseudoheader
-        return self.pack_hdr() + self.opts + str(self.data)
+        return self.pack_hdr() + str(self.opts) + str(self.data)
 
     def unpack(self, buf):
         dpkt.Packet.unpack(self, buf)

--- a/dpkt/tcp.py
+++ b/dpkt/tcp.py
@@ -52,7 +52,7 @@ class TCP(dpkt.Packet):
         return self.__hdr_len__ + len(self.opts) + len(self.data)
 
     def __str__(self):
-        return self.pack_hdr() + self.opts + str(self.data)
+        return self.pack_hdr() + str(self.opts) + str(self.data)
 
     def unpack(self, buf):
         dpkt.Packet.unpack(self, buf)


### PR DESCRIPTION
Don't assume that the raw packet data is a `str` object; convert it to `str` via the `str()` function first.  (The raw packet data might be a string-like buffer object.)