### PR TITLE
fix bug in IPv6 payload checksum generation

### DIFF
--- a/dpkt/ip6.py
+++ b/dpkt/ip6.py
@@ -111,7 +111,7 @@ class IP6(dpkt.Packet):
         return header_str
 
     def __str__(self):
-        if (self.nxt == 6 or self.nxt == 17 or self.nxt == 58) and not self.data.sum:
+        if (self.p == 6 or self.p == 17 or self.p == 58) and not self.data.sum:
             # XXX - set TCP, UDP, and ICMPv6 checksums
             p = str(self.data)
             s = dpkt.struct.pack('>16s16sxBH', self.src, self.dst, self.nxt, len(p))


### PR DESCRIPTION
When determining whether a checksum must be generated for the payload look at `IPV6.p` not `IPV6.nxt`.  `IPV6.p` is the protocol number of the payload, while `IPV6.nxt` is the protocol number of the next extension header (or payload if there is no extension header).