### PR TITLE
Fix travis python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ env:
   global:
     LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
   matrix:
-    - TOXENV=py25,coveralls
     - TOXENV=py26,coveralls
     - TOXENV=py27,coveralls
     - TOXENV=pypy,coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ env:
   global:
     LD_PRELOAD=/lib/x86_64-linux-gnu/libSegFault.so
   matrix:
+    - TOXENV=py25,coveralls
     - TOXENV=py26,coveralls
     - TOXENV=py27,coveralls
     - TOXENV=pypy,coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
 install:
   - pip install tox
 script:
-  - tox -v
+  - tox -e $TOXENV
 notifications:
   email:
     on_success: never

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py25, py26, py27, docs
+envlist = py26, py27, docs
 
 [testenv]
 install_command =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, docs
+envlist = py25, py26, py27, docs
 
 [testenv]
 install_command =


### PR DESCRIPTION
Small fix to ensure that travisCI is running python 2.6 and python 2.7. Unfortunately Travis does not support 2.4, or 2.5.