### PR TITLE
fix pypi_badges (using shields.io for badge server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ TCP/IP protocols
 [![landscape](https://landscape.io/github/kbandla/dpkt/master/landscape.svg?style=flat)](https://landscape.io/github/kbandla/dpkt/master)
 [![version](http://img.shields.io/pypi/v/dpkt.png?style=flat)](https://pypi.python.org/pypi/dpkt)
 
-[![downloads](http://img.shields.io/pypi/dm/dpkt.png?style=flat)](https://pypi.python.org/pypi/dpkt)
-[![wheel](https://pypip.in/wheel/dpkt/badge.png?style=flat)](https://pypi.python.org/pypi/dpkt)
-[![supported-versions](https://pypip.in/py_versions/dpkt/badge.png?style=flat)](https://pypi.python.org/pypi/dpkt)
-[![supported-implementations](https://pypip.in/implementation/dpkt/badge.png?style=flat)](https://pypi.python.org/pypi/dpkt)
+[![downloads](https://img.shields.io/pypi/dm/dpkt.png)](https://pypi.python.org/pypi/dpkt)
+[![wheel](https://img.shields.io/pypi/wheel/dpkt.svg)](https://pypi.python.org/pypi/dpkt)
+[![supported-versions](https://img.shields.io/pypi/pyversions/dpkt.svg)](https://pypi.python.org/pypi/dpkt)
+[![supported-implementations](https://img.shields.io/pypi/implementation/dpkt.svg)](https://pypi.python.org/pypi/dpkt)
 
 
 Installation

--- a/docs/badges.rst
+++ b/docs/badges.rst
@@ -19,23 +19,23 @@
     :target: https://landscape.io/github/kbandla/dpkt/master
     :alt: Code Quality Status
 
-.. |version| image:: http://img.shields.io/pypi/v/dpkt.png?style=flat
+.. |version| image:: http://img.shields.io/pypi/v/dpkt.svg
     :alt: PyPI Package latest release
     :target: https://pypi.python.org/pypi/dpkt
 
-.. |downloads| image:: http://img.shields.io/pypi/dm/dpkt.png?style=flat
+.. |downloads| image:: http://img.shields.io/pypi/dm/dpkt.svg
     :alt: PyPI Package monthly downloads
     :target: https://pypi.python.org/pypi/dpkt
 
-.. |wheel| image:: https://pypip.in/wheel/dpkt/badge.png?style=flat
+.. |wheel| image:: https://img.shields.io/pypi/wheel/dpkt.svg
     :alt: PyPI Wheel
     :target: https://pypi.python.org/pypi/dpkt
 
-.. |supported-versions| image:: https://pypip.in/py_versions/dpkt/badge.png?style=flat
+.. |supported-versions| image:: https://img.shields.io/pypi/pyversions/dpkt.svg
     :alt: Supported versions
     :target: https://pypi.python.org/pypi/dpkt
 
-.. |supported-implementations| image:: https://pypip.in/implementation/dpkt/badge.png?style=flat
+.. |supported-implementations| image:: https://img.shields.io/pypi/implementation/dpkt.svg 
     :alt: Supported implementations
     :target: https://pypi.python.org/pypi/dpkt
 


### PR DESCRIPTION
Seems like pypins is down (pypi as a whole continues to worry me)...
https://github.com/badges/pypipins/issues/37

Anyway using shields.io as pin server for our pypi badges.