### PR TITLE
Fix Issue #117: dpkt http wrong parse_headers logic.

### DIFF
--- a/dpkt/http.py
+++ b/dpkt/http.py
@@ -11,8 +11,6 @@ def parse_headers(f):
     d = {}
     while 1:
         line = f.readline()
-        if not line:
-            raise dpkt.NeedData('premature end of headers')
         line = line.strip()
         if not line:
             break


### PR DESCRIPTION
Hi @kbandla, I did some investigations on Issue #117. Here is a detailed description for this bug.

The problem is dpke could parse most of the HTTP packets, however sometimes it may raise `NeedData("premature end of headers")` exception. 

Hopefully the HTTP header ends with `\r\n\r\n`, but practically some of the packets are not with that ending. Here is an example I captured using Wireshark.

`Host: x.jd.com
Connection: keep-alive
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) 
 Chrome/40.0.2214.115 Safari/537.36
Referer: http://y0.ifengimg.com/mappa/2015/01/22/8467fe372da309ca74727a4af91ee20c.html
Accept-Encoding: gzip, deflate, sdch
Accept-Language: zh-CN,zh;q=0.8,en;q=0.6
Cookie: _pst=sunhao2014; TrackID=1PWdcr3MO_C611BGWJi_u-nDotO7jC8xU2M_oAON-
 W58NCds3C1F6bQRYDFFeSeMydoRk5R2qo8DJFNMIii1uoA; pinId=e3nZh6DHdRzvH6PAy6UGog; 
 pin=sunhao2014; unick=DreamingInCode; _tp=gKQwy5c16Th%2BRWjdagTF4g%3D%3D; user-
 key=95f5a8ba-8e80-4ebf-8855-8405a9195678; __utmz=122270672.1433142066.1.1.utmcsr=trade.jd.
 com|utmccn=(referral)|utmcmd=referral|utmcct=/shopping/order/getOrderInfo.action; 
 unpl=V2_ZzNsbUZeREd0DBRccxtfAGJRQF9KVEccc11DVXkRC1UzAhtaclRCFXEUR1NnGV8UZgoZWUN
 cQBdFCHZXfB9sBmQHFl1yZ0MWRQl2VHMZXQBvAhFaSmc%3D; mt_subsite=|125%2C1434070223|; 
 cn=0; ads_info=t=2...`

In our current implementation, we'll raise the aforementioned `NeedData` exception. However we can see the attached HTTP packet is valid and should be parsed without exception. Thus I modified the original logic. There are two cases which will lead to the `break` clause on Line 16. One is we have reached the end of header string but it doesn't end with '\r\n\r\n', for this case, we directly complete the header parsing with out raising the exception. The other case is the header part ends, so after `strip()` we'll also break the loop and continue parsing the body.