### PR TITLE
Fix multiple pcap.Reader issues

### DIFF
--- a/dpkt/pcap.py
+++ b/dpkt/pcap.py
@@ -192,27 +192,27 @@ def test_pcap_endian():
     assert (befh.linktype == lefh.linktype)
 
 
-def test_reader_stringio():
+def test_reader_stringio(data):
     # StringIO
     import StringIO
-    fobj = StringIO.StringIO(libpcap_data)
+    fobj = StringIO.StringIO(data)
     reader = Reader(fobj)
     assert reader.name == '<StringIO>'
     _, buf1 = iter(reader).next()
-    assert buf1 == libpcap_data[FileHdr.__hdr_len__ + PktHdr.__hdr_len__:]
+    assert buf1 == data[FileHdr.__hdr_len__ + PktHdr.__hdr_len__:]
 
     # cStringIO
     import cStringIO
-    fobj = cStringIO.StringIO(libpcap_data)
+    fobj = cStringIO.StringIO(data)
     reader = Reader(fobj)
     assert reader.name == '<StringI>'
     _, buf1 = iter(reader).next()
-    assert buf1 == libpcap_data[FileHdr.__hdr_len__ + PktHdr.__hdr_len__:]
+    assert buf1 == data[FileHdr.__hdr_len__ + PktHdr.__hdr_len__:]
 
 
-def test_reader_dispatch():
+def test_reader_dispatch(data):
     import StringIO
-    fobj = StringIO.StringIO(libpcap_data)
+    fobj = StringIO.StringIO(data)
 
     # test count = 0
     reader = Reader(fobj)
@@ -238,7 +238,7 @@ if __name__ == '__main__':
         '\xaa\x14\x80\x1b\x00\x35\x00\x24\x85\xed'
     )
     test_pcap_endian()
-    test_reader_stringio()
-    test_reader_dispatch()
+    test_reader_stringio(data=libpcap_data)
+    test_reader_dispatch(data=libpcap_data)
 
     print 'Tests Successful...'

--- a/dpkt/pcap.py
+++ b/dpkt/pcap.py
@@ -146,8 +146,9 @@ class Reader(object):
         return self.__iter.next()
 
     def dispatch(self, cnt, callback, *args):
-        """Collect and process packets with a user callback,
-        return the number of packets processed, or 0 for a savefile.
+        """Collect and process packets with a user callback.
+
+        Return the number of packets processed, or 0 for a savefile.
 
         Arguments:
 

--- a/dpkt/pcap.py
+++ b/dpkt/pcap.py
@@ -124,6 +124,7 @@ class Reader(object):
             self.dloff = 0
         self.snaplen = self.__fh.snaplen
         self.filter = ''
+        self.__iter = iter(self)
 
     @property
     def fd(self):
@@ -141,14 +142,34 @@ class Reader(object):
     def readpkts(self):
         return list(self)
 
+    def next(self):
+        return self.__iter.next()
+
     def dispatch(self, cnt, callback, *args):
+        """Collect and process packets with a user callback,
+        return the number of packets processed, or 0 for a savefile.
+
+        Arguments:
+
+        cnt      -- number of packets to process;
+                    or 0 to process all packets until EOF
+        callback -- function with (timestamp, pkt, *args) prototype
+        *args    -- optional arguments passed to callback on execution
+        """
+        processed = 0
         if cnt > 0:
-            for i in range(cnt):
-                ts, pkt = self.next()
+            for _ in range(cnt):
+                try:
+                    ts, pkt = self.next()
+                except StopIteration:
+                    break
                 callback(ts, pkt, *args)
+                processed += 1
         else:
             for ts, pkt in self:
                 callback(ts, pkt, *args)
+                processed += 1
+        return processed
 
     def loop(self, callback, *args):
         self.dispatch(0, callback, *args)
@@ -189,6 +210,26 @@ def test_reader_stringio():
     assert buf1 == libpcap_data[FileHdr.__hdr_len__ + PktHdr.__hdr_len__:]
 
 
+def test_reader_dispatch():
+    import StringIO
+    fobj = StringIO.StringIO(libpcap_data)
+
+    # test count = 0
+    reader = Reader(fobj)
+    assert reader.dispatch(0, lambda ts, pkt: None) == 1
+
+    # test count > 0
+    fobj.seek(0)
+    reader = Reader(fobj)
+    assert reader.dispatch(4, lambda ts, pkt: None) == 1
+
+    # test iterative dispatch
+    fobj.seek(0)
+    reader = Reader(fobj)
+    assert reader.dispatch(1, lambda ts, pkt: None) == 1
+    assert reader.dispatch(1, lambda ts, pkt: None) == 0
+
+
 if __name__ == '__main__':
     libpcap_data = (  # full libpcap file with one packet
         '\xd4\xc3\xb2\xa1\x02\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\x00\x00\x01\x00\x00\x00'
@@ -198,5 +239,6 @@ if __name__ == '__main__':
     )
     test_pcap_endian()
     test_reader_stringio()
+    test_reader_dispatch()
 
     print 'Tests Successful...'

--- a/dpkt/pcap.py
+++ b/dpkt/pcap.py
@@ -193,7 +193,16 @@ def test_pcap_endian():
     assert (befh.linktype == lefh.linktype)
 
 
-def test_reader_stringio(data):
+def test_reader():
+    data = (  # full libpcap file with one packet
+        '\xd4\xc3\xb2\xa1\x02\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\x00\x00\x01\x00\x00\x00'
+        '\xb2\x67\x4a\x42\xae\x91\x07\x00\x46\x00\x00\x00\x46\x00\x00\x00\x00\xc0\x9f\x32\x41\x8c\x00\xe0'
+        '\x18\xb1\x0c\xad\x08\x00\x45\x00\x00\x38\x00\x00\x40\x00\x40\x11\x65\x47\xc0\xa8\xaa\x08\xc0\xa8'
+        '\xaa\x14\x80\x1b\x00\x35\x00\x24\x85\xed'
+    )
+
+    # --- StringIO tests ---
+
     # StringIO
     import StringIO
     fobj = StringIO.StringIO(data)
@@ -210,12 +219,10 @@ def test_reader_stringio(data):
     _, buf1 = iter(reader).next()
     assert buf1 == data[FileHdr.__hdr_len__ + PktHdr.__hdr_len__:]
 
-
-def test_reader_dispatch(data):
-    import StringIO
-    fobj = StringIO.StringIO(data)
+    # --- dispatch() tests ---
 
     # test count = 0
+    fobj.seek(0)
     reader = Reader(fobj)
     assert reader.dispatch(0, lambda ts, pkt: None) == 1
 
@@ -232,14 +239,7 @@ def test_reader_dispatch(data):
 
 
 if __name__ == '__main__':
-    libpcap_data = (  # full libpcap file with one packet
-        '\xd4\xc3\xb2\xa1\x02\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\x00\x00\x01\x00\x00\x00'
-        '\xb2\x67\x4a\x42\xae\x91\x07\x00\x46\x00\x00\x00\x46\x00\x00\x00\x00\xc0\x9f\x32\x41\x8c\x00\xe0'
-        '\x18\xb1\x0c\xad\x08\x00\x45\x00\x00\x38\x00\x00\x40\x00\x40\x11\x65\x47\xc0\xa8\xaa\x08\xc0\xa8'
-        '\xaa\x14\x80\x1b\x00\x35\x00\x24\x85\xed'
-    )
     test_pcap_endian()
-    test_reader_stringio(data=libpcap_data)
-    test_reader_dispatch(data=libpcap_data)
+    test_reader()
 
     print 'Tests Successful...'


### PR DESCRIPTION
- make pcap.Reader's fileobj STDIN and [c]StringIO compatible;
- fix a dispatch() issue #105 and make it closer to pypcap implementation (took the docstring from there);
- add unit tests.