### PR TITLE
Issue #193 - multiple improvements to dpkt.Packet.__repr__()

### DIFF
--- a/dpkt/dpkt.py
+++ b/dpkt/dpkt.py
@@ -114,21 +114,22 @@ class Packet(object):
 
         l = []
         # maintain order of fields as defined in __hdr__
-        for k, _, _ in getattr(self, '__hdr__', []):
-            vv = getattr(self, k)
-            if vv != self.__hdr_defaults__[k]:
-                if k[0] != '_':
-                    l.append('%s=%r' % (k, vv))  # (1)
+        for field_name, _, _ in getattr(self, '__hdr__', []):
+            field_value = getattr(self, field_name)
+            if field_value != self.__hdr_defaults__[field_name]:
+                if field_name[0] != '_':
+                    l.append('%s=%r' % (field_name, field_value))  # (1)
                 else:
-                    for pp in k.split('_'):      # (2)
-                        if isinstance(getattr(self.__class__, pp, None), property):
-                            l.append('%s=%r' % (pp, getattr(self, pp)))
+                    # interpret _private fields as name of properties joined by underscores
+                    for prop_name in field_name.split('_'):        # (2)
+                        if isinstance(getattr(self.__class__, prop_name, None), property):
+                            l.append('%s=%r' % (prop_name, getattr(self, prop_name)))
         # (3)
         l.extend(
-            ['%s=%r' % (k, v)
-             for k, v in self.__dict__.iteritems()
-             if k[0] != '_'                   # exclude _private attributes
-             and k != self.data.__class__.__name__.lower()])  # exclude fields like ip.udp
+            ['%s=%r' % (attr_name, attr_value)
+             for attr_name, attr_value in self.__dict__.iteritems()
+             if attr_name[0] != '_'                   # exclude _private attributes
+             and attr_name != self.data.__class__.__name__.lower()])  # exclude fields like ip.udp
         # (4)
         if self.data:
             l.append('data=%r' % self.data)

--- a/dpkt/dpkt.py
+++ b/dpkt/dpkt.py
@@ -110,9 +110,10 @@ class Packet(object):
               for k in self.__hdr_defaults__
               if getattr(self, k) != self.__hdr_defaults__[k]] +
 
-             ['%s=%r' % (k, getattr(self, k))  # dynamically added fields
-              for k in self.__dict__.iterkeys()
-              if k not in self.__hdr_fields__])
+             ['%s=%r' % (k, v)                 # dynamically added fields
+              for k, v in self.__dict__.iteritems()
+              if k[0] != '_' and    # exclude "_private" attributes
+                 k != self.data.__class__.__name__.lower()])  # exclude fields like ip.udp
 
         if self.data:
             l.append('data=%r' % self.data)

--- a/dpkt/dpkt.py
+++ b/dpkt/dpkt.py
@@ -9,16 +9,20 @@ import struct
 import array
 
 
-class Error(Exception): pass
+class Error(Exception):
+    pass
 
 
-class UnpackError(Error): pass
+class UnpackError(Error):
+    pass
 
 
-class NeedData(UnpackError): pass
+class NeedData(UnpackError):
+    pass
 
 
-class PackError(Error): pass
+class PackError(Error):
+    pass
 
 
 class _MetaPacket(type):
@@ -30,8 +34,7 @@ class _MetaPacket(type):
             clsdict['__slots__'] = [x[0] for x in st] + ['data']
             t = type.__new__(cls, clsname, clsbases, clsdict)
             t.__hdr_fields__ = [x[0] for x in st]
-            t.__hdr_fmt__ = getattr(t, '__byte_order__', '>') + \
-                            ''.join([x[1] for x in st])
+            t.__hdr_fmt__ = getattr(t, '__byte_order__', '>') + ''.join([x[1] for x in st])
             t.__hdr_len__ = struct.calcsize(t.__hdr_fmt__)
             t.__hdr_defaults__ = dict(zip(
                 t.__hdr_fields__, [x[2] for x in st]))
@@ -103,9 +106,14 @@ class Packet(object):
             raise KeyError
 
     def __repr__(self):
-        l = ['%s=%r' % (k, getattr(self, k))
-             for k in self.__hdr_defaults__
-             if getattr(self, k) != self.__hdr_defaults__[k]]
+        l = (['%s=%r' % (k, getattr(self, k))  # fields defined in __hdr__
+              for k in self.__hdr_defaults__
+              if getattr(self, k) != self.__hdr_defaults__[k]] +
+
+             ['%s=%r' % (k, getattr(self, k))  # dynamically added fields
+              for k in self.__dict__.iterkeys()
+              if k not in self.__hdr_fields__])
+
         if self.data:
             l.append('data=%r' % self.data)
         return '%s(%s)' % (self.__class__.__name__, ', '.join(l))
@@ -158,6 +166,7 @@ def hexdump(buf, length=16):
         n += length
     return '\n'.join(res)
 
+
 def in_cksum_add(s, buf):
     n = len(buf)
     cnt = (n / 2) * 2
@@ -166,10 +175,12 @@ def in_cksum_add(s, buf):
         a.append(struct.unpack('H', buf[-1] + '\x00')[0])
     return s + sum(a)
 
+
 def in_cksum_done(s):
     s = (s >> 16) + (s & 0xffff)
     s += (s >> 16)
     return socket.ntohs(~s & 0xffff)
+
 
 def in_cksum(buf):
     """Return computed Internet checksum."""

--- a/dpkt/gre.py
+++ b/dpkt/gre.py
@@ -107,8 +107,6 @@ class GRE(dpkt.Packet):
         opt_fmtlen = struct.calcsize(''.join(self.opt_fields_fmts()[1]))
         return self.__hdr_len__ + opt_fmtlen + sum(map(len, self.sre)) + len(self.data)
 
-    # XXX - need to fix up repr to display optional fields...
-
     def __str__(self):
         fields, fmts = self.opt_fields_fmts()
         if fields:

--- a/dpkt/ip.py
+++ b/dpkt/ip.py
@@ -8,7 +8,7 @@ from decorators import deprecated
 
 class IP(dpkt.Packet):
     __hdr__ = (
-        ('v_hl', 'B', (4 << 4) | (20 >> 2)),
+        ('_v_hl', 'B', (4 << 4) | (20 >> 2)),
         ('tos', 'B', 0),
         ('len', 'H', 20),
         ('id', 'H', 0),
@@ -24,19 +24,19 @@ class IP(dpkt.Packet):
 
     @property
     def v(self):
-        return self.v_hl >> 4
+        return self._v_hl >> 4
 
     @v.setter
     def v(self, v):
-        self.v_hl = (v << 4) | (self.v_hl & 0xf)
+        self._v_hl = (v << 4) | (self._v_hl & 0xf)
 
     @property
     def hl(self):
-        return self.v_hl & 0xf
+        return self._v_hl & 0xf
 
     @hl.setter
     def hl(self, hl):
-        self.v_hl = (self.v_hl & 0xf0) | hl
+        self._v_hl = (self._v_hl & 0xf0) | hl
 
     # Deprecated methods, will be removed in the future
     # =================================================
@@ -79,7 +79,7 @@ class IP(dpkt.Packet):
 
     def unpack(self, buf):
         dpkt.Packet.unpack(self, buf)
-        ol = ((self.v_hl & 0xf) << 2) - self.__hdr_len__
+        ol = ((self._v_hl & 0xf) << 2) - self.__hdr_len__
         if ol < 0:
             raise dpkt.UnpackError, 'invalid header length'
         self.opts = buf[self.__hdr_len__:self.__hdr_len__ + ol]

--- a/dpkt/ip6.py
+++ b/dpkt/ip6.py
@@ -8,7 +8,7 @@ from decorators import deprecated
 
 class IP6(dpkt.Packet):
     __hdr__ = (
-        ('v_fc_flow', 'I', 0x60000000L),
+        ('_v_fc_flow', 'I', 0x60000000L),
         ('plen', 'H', 0),  # payload length (not including header)
         ('nxt', 'B', 0),  # next header protocol
         ('hlim', 'B', 0),  # hop limit
@@ -23,27 +23,27 @@ class IP6(dpkt.Packet):
 
     @property
     def v(self):
-        return self.v_fc_flow >> 28
+        return self._v_fc_flow >> 28
 
     @v.setter
     def v(self, v):
-        self.v_fc_flow = (self.v_fc_flow & ~0xf0000000L) | (v << 28)
+        self._v_fc_flow = (self._v_fc_flow & ~0xf0000000L) | (v << 28)
 
     @property
     def fc(self):
-        return (self.v_fc_flow >> 20) & 0xff
+        return (self._v_fc_flow >> 20) & 0xff
 
     @fc.setter
     def fc(self, v):
-        self.v_fc_flow = (self.v_fc_flow & ~0xff00000L) | (v << 20)
+        self._v_fc_flow = (self._v_fc_flow & ~0xff00000L) | (v << 20)
 
     @property
     def flow(self):
-        return self.v_fc_flow & 0xfffff
+        return self._v_fc_flow & 0xfffff
 
     @flow.setter
     def flow(self, v):
-        self.v_fc_flow = (self.v_fc_flow & ~0xfffff) | (v & 0xfffff)
+        self._v_fc_flow = (self._v_fc_flow & ~0xfffff) | (v & 0xfffff)
 
     # Deprecated methods, will be removed in the future
     # =================================================
@@ -185,10 +185,12 @@ class IP6OptsHeader(IP6ExtensionHeader):
         setattr(self, 'options', options)
 
 
-class IP6HopOptsHeader(IP6OptsHeader): pass
+class IP6HopOptsHeader(IP6OptsHeader):
+    pass
 
 
-class IP6DstOptsHeader(IP6OptsHeader): pass
+class IP6DstOptsHeader(IP6OptsHeader):
+    pass
 
 
 class IP6RoutingHeader(IP6ExtensionHeader):

--- a/dpkt/pim.py
+++ b/dpkt/pim.py
@@ -8,22 +8,26 @@ from decorators import deprecated
 
 class PIM(dpkt.Packet):
     __hdr__ = (
-        ('v_type', 'B', 0x20),
+        ('_v_type', 'B', 0x20),
         ('rsvd', 'B', 0),
         ('sum', 'H', 0)
     )
 
     @property
-    def v(self): return self.v_type >> 4
+    def v(self):
+        return self._v_type >> 4
 
     @v.setter
-    def v(self, v): self.v_type = (v << 4) | (self.v_type & 0xf)
+    def v(self, v):
+        self._v_type = (v << 4) | (self._v_type & 0xf)
 
     @property
-    def type(self): return self.v_type & 0xf
+    def type(self):
+        return self._v_type & 0xf
 
     @type.setter
-    def type(self, type): self.v_type = (self.v_type & 0xf0) | type
+    def type(self, type):
+        self._v_type = (self._v_type & 0xf0) | type
 
     # Deprecated methods, will be removed in the future
     # =================================================

--- a/dpkt/pppoe.py
+++ b/dpkt/pppoe.py
@@ -17,23 +17,27 @@ PPPoE_SESSION = 0x00
 
 class PPPoE(dpkt.Packet):
     __hdr__ = (
-        ('v_type', 'B', 0x11),
+        ('_v_type', 'B', 0x11),
         ('code', 'B', 0),
         ('session', 'H', 0),
         ('len', 'H', 0)  # payload length
     )
 
     @property
-    def v(self): return self.v_type >> 4
+    def v(self):
+        return self._v_type >> 4
 
     @v.setter
-    def v(self, v): self.v_type = (v << 4) | (self.v_type & 0xf)
+    def v(self, v):
+        self._v_type = (v << 4) | (self._v_type & 0xf)
 
     @property
-    def type(self): return self.v_type & 0xf
+    def type(self):
+        return self._v_type & 0xf
 
     @type.setter
-    def type(self, t): self.v_type = (self.v_type & 0xf0) | t
+    def type(self, t):
+        self._v_type = (self._v_type & 0xf0) | t
 
     # Deprecated methods, will be removed in the future
     # =================================================

--- a/dpkt/tcp.py
+++ b/dpkt/tcp.py
@@ -25,7 +25,7 @@ class TCP(dpkt.Packet):
         ('dport', 'H', 0),
         ('seq', 'I', 0xdeadbeefL),
         ('ack', 'I', 0),
-        ('off_x2', 'B', ((5 << 4) | 0)),
+        ('_off', 'B', ((5 << 4) | 0)),
         ('flags', 'B', TH_SYN),
         ('win', 'H', TCP_WIN_MAX),
         ('sum', 'H', 0),
@@ -34,10 +34,12 @@ class TCP(dpkt.Packet):
     opts = ''
 
     @property
-    def off(self): return self.off_x2 >> 4
+    def off(self):
+        return self._off >> 4
 
     @off.setter
-    def off(self, off): self.off_x2 = (off << 4) | (self.off_x2 & 0xf)
+    def off(self, off):
+        self._off = (off << 4) | (self._off & 0xf)
 
     # Deprecated methods, will be removed in the future
     # =================================================
@@ -56,7 +58,7 @@ class TCP(dpkt.Packet):
 
     def unpack(self, buf):
         dpkt.Packet.unpack(self, buf)
-        ol = ((self.off_x2 >> 4) << 2) - self.__hdr_len__
+        ol = ((self._off >> 4) << 2) - self.__hdr_len__
         if ol < 0:
             raise dpkt.UnpackError, 'invalid header length'
         self.opts = buf[self.__hdr_len__:self.__hdr_len__ + ol]

--- a/dpkt/vrrp.py
+++ b/dpkt/vrrp.py
@@ -8,7 +8,7 @@ from decorators import deprecated
 
 class VRRP(dpkt.Packet):
     __hdr__ = (
-        ('vtype', 'B', 0x21),
+        ('_v_type', 'B', 0x21),
         ('vrid', 'B', 0),
         ('priority', 'B', 0),
         ('count', 'B', 0),
@@ -20,20 +20,20 @@ class VRRP(dpkt.Packet):
     auth = ''
 
     @property
-    def v(self):  # high 4 bits of vtype
-        return self.vtype >> 4
+    def v(self):  # high 4 bits of _v_type
+        return self._v_type >> 4
 
     @v.setter
     def v(self, v):
-        self.vtype = (self.vtype & 0x0f) | (v << 4)
+        self._v_type = (self._v_type & 0x0f) | (v << 4)
 
     @property
-    def type(self):  # low 4 bits of vtype
-        return self.vtype & 0x0f
+    def type(self):  # low 4 bits of _v_type
+        return self._v_type & 0x0f
 
     @type.setter
     def type(self, v):
-        self.vtype = (self.vtype & 0xf0) | (v & 0x0f)
+        self._v_type = (self._v_type & 0xf0) | (v & 0x0f)
 
     # Deprecated methods, will be removed in the future
     # =================================================


### PR DESCRIPTION
@kbandla @brifordwylie @saylenty and others - please comment what you think of this. See #193 for details of what I tried to achieve. Here are some examples of packet representation before and after the suggested change (new lines and indent added manually for better looks).


ETH/TCP/IP stack
```python
Ethernet(src='\x00\xa0\xcc;\xbf\xfa', dst='\x00\x00\xc0\x9f\xa0\x97',
         data=IP(src='\xc0\xa8\x00\x02', off=16384, dst='\xc0\xa8\x00\x01', tos=16, sum=29468, len=60, p=6, id=17980,
                 data=TCP(seq=2579865836, off_x2=160, win=32120, sum=57507, dport=23, sport=1550)))

Ethernet(dst='\x00\x00\xc0\x9f\xa0\x97', src='\x00\xa0\xcc;\xbf\xfa',
         data=IP(tos=16, len=60, id=17980, off=16384, p=6, sum=29468, src='\xc0\xa8\x00\x02', dst='\xc0\xa8\x00\x01', opts='',
                 data=TCP(sport=1550, dport=23, seq=2579865836, off=10, win=32120, sum=57507, opts="\x02\x04\x05\xb4\x04\x02\x08\n\x00\x9c'$\x00\x00\x00\x00\x01\x03\x03\x00")))
```

ETH w/ MPLS labels

```python
Ethernet(src='\xcc\x04\x04\xdc\x00\x10', dst='\xcc\x03\x04\xdc\x00\x10', data='...')

Ethernet(dst='\xcc\x03\x04\xdc\x00\x10', src='\xcc\x04\x04\xdc\x00\x10', labels=[(19, 0, 254), (16, 0, 255)], data='...')
```


GRE

```python
GRE(p=34827, flags=12289, data=PPP(p=255, data='...'))))

GRE(flags=12289, p=34827, callid=6144, len=3584, seq=0, data=PPP(p=255, data='...'))))
```


VRRP

```python
VRRP(count=1, advtime=1, sum=47698, vrid=1, priority=100)

VRRP(vrid=1, priority=100, count=1, advtime=1, sum=47698, addrs=['\xc0\xa8\x00\x01'], auth='\x00\x00\x00\x00\x00\x00\x00\x00')
```


STP

```python
STP(max_age=5120, root_id="\x80\x00\x08\x00'\xad\xa3A", bridge_id="\x80\x00\x08\x00'\xad\xa3A", port_id=32769, hello=512, flags=62, v=2, fd=3840, type=2,
    data='...')

STP(v=2, type=2, flags=62, root_id="\x80\x00\x08\x00'\xad\xa3A", bridge_id="\x80\x00\x08\x00'\xad\xa3A", port_id=32769, age=0, hello=2, fd=15,
    data='...')
```


IPv6

```python
IP6(src=' H\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca', nxt=43, dst=' G\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xca\xfe', hlim=64, plen=60,
    data=TCP(seq=0, win=8192, sum=37247, dport=80, sport=20))

IP6(plen=60, nxt=43, hlim=64, src=' H\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca', dst=' G\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xca\xfe', p=6,
    extension_hdrs={0: None, 43: IP6RoutingHeader(nxt=6, len=4, segs_left=2, length=40, addresses=[' \x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca', ' "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xca'],
    data='...'), 44: None, 50: None, 51: None, 60: None},
    data=TCP(sport=20, dport=80, seq=0, win=8192, sum=37247, opts=''))
```
