### PR TITLE
Fix dynamic imports

### DIFF
--- a/dpkt/aoe.py
+++ b/dpkt/aoe.py
@@ -80,10 +80,10 @@ def __load_cmds():
         if k.startswith(prefix):
             name = 'aoe' + k[len(prefix):].lower()
             try:
-                mod = __import__(name, g)
-            except ImportError:
+                mod = __import__(name, g, level=1)
+                AOE.set_cmd(v, getattr(mod, name.upper()))
+            except (ImportError, AttributeError):
                 continue
-            AOE.set_cmd(v, getattr(mod, name.upper()))
 
 
 if not AOE._cmdsw:

--- a/dpkt/ethernet.py
+++ b/dpkt/ethernet.py
@@ -124,10 +124,10 @@ def __load_types():
             name = k[9:]
             modname = name.lower()
             try:
-                mod = __import__(modname, g)
-            except ImportError:
+                mod = __import__(modname, g, level=0)
+                Ethernet.set_type(v, getattr(mod, name))
+            except (ImportError, AttributeError):
                 continue
-            Ethernet.set_type(v, getattr(mod, name))
 
 
 if not Ethernet._typesw:

--- a/dpkt/ethernet.py
+++ b/dpkt/ethernet.py
@@ -124,7 +124,7 @@ def __load_types():
             name = k[9:]
             modname = name.lower()
             try:
-                mod = __import__(modname, g, level=0)
+                mod = __import__(modname, g, level=1)
                 Ethernet.set_type(v, getattr(mod, name))
             except (ImportError, AttributeError):
                 continue

--- a/dpkt/ip.py
+++ b/dpkt/ip.py
@@ -298,10 +298,10 @@ def __load_protos():
         if k.startswith('IP_PROTO_'):
             name = k[9:].lower()
             try:
-                mod = __import__(name, g)
-            except ImportError:
+                mod = __import__(name, g, level=1)
+                IP.set_proto(v, getattr(mod, name.upper()))
+            except (ImportError, AttributeError):
                 continue
-            IP.set_proto(v, getattr(mod, name.upper()))
 
 
 if not IP._protosw:

--- a/dpkt/ppp.py
+++ b/dpkt/ppp.py
@@ -56,10 +56,10 @@ def __load_protos():
             name = k[4:]
             modname = name.lower()
             try:
-                mod = __import__(modname, g)
-            except ImportError:
+                mod = __import__(modname, g, level=1)
+                PPP.set_p(v, getattr(mod, name))
+            except (ImportError, AttributeError):
                 continue
-            PPP.set_p(v, getattr(mod, name))
 
 
 if not PPP._protosw:


### PR DESCRIPTION
This is a fix for #61 and #141. We now make sure that modules-to-import are searched 'relative to the directory of the module'.