### PR TITLE
Fix #104: icmp6 type/code slip duplicate.

### DIFF
--- a/dpkt/icmp6.py
+++ b/dpkt/icmp6.py
@@ -74,4 +74,4 @@ class ICMP6(dpkt.Packet):
             self.data = self._typesw[self.type](self.data)
             setattr(self, self.data.__class__.__name__.lower(), self.data)
         except (KeyError, dpkt.UnpackError):
-            self.data = buf
+            pass


### PR DESCRIPTION
See more details about this issue on #104.
The reason why we have this problem is mentioned in #86.

>The problem is dpkt doesn't have handlers for all possible icmp6 types (for example, missing important ones like neighbour solitication == 135). In this case the key lookup fails in _typesw, but you don't want to set self.data, because this will throw off the length calculation and you will end up with bad icmp6 checksums.

Actually we have fixed the similar problem in `icmp.py` many years ago (see http://code.google.com/p/dpkt/source/detail?r=45). But in `icmp6.py` the problem is still remaining. This PR simply fix this issue in `icmp6.py`.

By trying the test script below, we could verify the validity of this update.

``` python
from binascii import *
from dpkt import ethernet

buf = "\x00\x23\x14\x00\x8b\x3c\x00\x0c\x29\xea\x6f\xad\x86\xdd\x60\x00\x00\x00\x00\x20\x3a\xff\xfe\x80\x00\x00\x00\x00\x00\x00\x02\x0c\x29\xff\xfe\xea\x6f\xad\xfe\x80\x00\x00\x00\x00\x00\x00\x65\x5d\xc7\xef\xb7\x98\x39\x13\x87\x00\x0b\xe8\x00\x00\x00\x00\xfe\x80\x00\x00\x00\x00\x00\x00\x65\x5d\xc7\xef\xb7\x98\x39\x13\x01\x01\x00\x0c\x29\xea\x6f\xad"
print b2a_hex(buf)
frame = ethernet.Ethernet(buf)
print b2a_hex(str(frame))
```