### PR TITLE
We now correctly parse IGMPv2 group TLV.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ pip-log.txt
 
 # ReadTheDocs build directory
 _build
+
+# Emacs backup files
+*~

--- a/dpkt/__init__.py
+++ b/dpkt/__init__.py
@@ -19,6 +19,8 @@ import dhcp
 import diameter
 import dns
 import dtp
+import dot1q
+import edp
 import esp
 import ethernet
 import gre

--- a/dpkt/dot1q.py
+++ b/dpkt/dot1q.py
@@ -1,0 +1,91 @@
+"""IEEE 802.1q"""
+
+import struct
+import dpkt
+
+# Ethernet payload types - http://standards.ieee.org/regauth/ethertype
+ETH_TYPE_PUP = 0x0200  # PUP protocol
+ETH_TYPE_IP = 0x0800  # IP protocol
+ETH_TYPE_ARP = 0x0806  # address resolution protocol
+ETH_TYPE_CDP = 0x2000  # Cisco Discovery Protocol
+ETH_TYPE_DTP = 0x2004  # Cisco Dynamic Trunking Protocol
+ETH_TYPE_REVARP = 0x8035  # reverse addr resolution protocol
+ETH_TYPE_DOT1Q = 0x8100  # IEEE 802.1Q VLAN tagging
+ETH_TYPE_IPX = 0x8137  # Internetwork Packet Exchange
+ETH_TYPE_IP6 = 0x86DD  # IPv6 protocol
+ETH_TYPE_PPP = 0x880B  # PPP
+ETH_TYPE_MPLS = 0x8847  # MPLS
+ETH_TYPE_MPLS_MCAST = 0x8848  # MPLS Multicast
+ETH_TYPE_PPPoE_DISC = 0x8863  # PPP Over Ethernet Discovery Stage
+ETH_TYPE_PPPoE = 0x8864  # PPP Over Ethernet Session Stage
+
+class DOT1Q(dpkt.Packet):
+    __hdr__ = (
+        ('x2', 'H', 0),
+        ('type', 'H', 0)
+        )
+    _typesw = {}
+
+    # pcp == Priority Code Point(802.1p)
+    def _get_pcp(self): return self.x2 >> 13
+    def _set_pcp(self, pcp): self.x2 = (self.x2 & 0x1fff) | (pcp << 13)
+    pcp = property(_get_pcp, _set_pcp)
+
+    # dei == Drop Eligible Indicator(almost never actually used)
+    def _get_dei(self): return (self.x2 >> 12) & 1 
+    def _set_dei(self, dei): self.x2 = (self.x2 & 61439) | (dei << 12)
+    dei = property(_get_dei, _set_dei)
+
+    # tag == vlan tag
+    def _get_tag(self): return self.x2 & (65535 >> 4)
+    def _set_tag(self, tag): self.x2 = (self.x2 & 0xfff) | tag
+    tag = property(_get_tag, _set_tag)
+
+    def set_type(cls, t, pktclass):
+        cls._typesw[t] = pktclass
+    set_type = classmethod(set_type)
+
+    def get_type(cls, t):
+        return cls._typesw[t]
+    get_type = classmethod(get_type)
+
+    def _unpack_data(self, buf):
+      if self.type == ETH_TYPE_MPLS or \
+            self.type == ETH_TYPE_MPLS_MCAST:
+        # XXX - skip labels (max # of labels is undefined, just use 24)
+        self.labels = []
+        for i in range(24):
+          entry = struct.unpack('>I', buf[i*4:i*4+4])[0]
+          label = ((entry & MPLS_LABEL_MASK) >> MPLS_LABEL_SHIFT, \
+                     (entry & MPLS_QOS_MASK) >> MPLS_QOS_SHIFT, \
+                     (entry & MPLS_TTL_MASK) >> MPLS_TTL_SHIFT)
+          self.labels.append(label)
+          if entry & MPLS_STACK_BOTTOM:
+            break
+          self.type = ETH_TYPE_IP
+          buf = buf[(i + 1) * 4:]
+      try:
+        self.data = self._typesw[self.type](buf)
+        setattr(self, self.data.__class__.__name__.lower(), self.data)
+      except (KeyError, dpkt.UnpackError):
+        self.data = buf
+
+    def unpack(self, buf):
+        dpkt.Packet.unpack(self, buf)
+        self._unpack_data(self.data)
+
+# XXX - auto-load Ethernet dispatch table from ETH_TYPE_* definitions
+def __load_types():
+  g = globals()
+  for k, v in g.iteritems():
+    if k.startswith('ETH_TYPE_'):
+      name = k[9:]
+      modname = name.lower()
+      try:
+        mod = __import__(modname, g)
+      except ImportError:
+        continue
+      DOT1Q.set_type(v, getattr(mod, name))
+
+if not DOT1Q._typesw:
+  __load_types()

--- a/dpkt/dot1q.py
+++ b/dpkt/dot1q.py
@@ -50,25 +50,25 @@ class DOT1Q(dpkt.Packet):
     get_type = classmethod(get_type)
 
     def _unpack_data(self, buf):
-      if self.type == ETH_TYPE_MPLS or \
-            self.type == ETH_TYPE_MPLS_MCAST:
-        # XXX - skip labels (max # of labels is undefined, just use 24)
-        self.labels = []
-        for i in range(24):
-          entry = struct.unpack('>I', buf[i*4:i*4+4])[0]
-          label = ((entry & MPLS_LABEL_MASK) >> MPLS_LABEL_SHIFT, \
-                     (entry & MPLS_QOS_MASK) >> MPLS_QOS_SHIFT, \
-                     (entry & MPLS_TTL_MASK) >> MPLS_TTL_SHIFT)
-          self.labels.append(label)
-          if entry & MPLS_STACK_BOTTOM:
-            break
-          self.type = ETH_TYPE_IP
-          buf = buf[(i + 1) * 4:]
-      try:
-        self.data = self._typesw[self.type](buf)
-        setattr(self, self.data.__class__.__name__.lower(), self.data)
-      except (KeyError, dpkt.UnpackError):
-        self.data = buf
+        if self.type == ETH_TYPE_MPLS or \
+                self.type == ETH_TYPE_MPLS_MCAST:
+            # XXX - skip labels (max # of labels is undefined, just use 24)
+            self.labels = []
+            for i in range(24):
+                entry = struct.unpack('>I', buf[i*4:i*4+4])[0]
+                label = ((entry & MPLS_LABEL_MASK) >> MPLS_LABEL_SHIFT, \
+                           (entry & MPLS_QOS_MASK) >> MPLS_QOS_SHIFT, \
+                           (entry & MPLS_TTL_MASK) >> MPLS_TTL_SHIFT)
+                self.labels.append(label)
+                if entry & MPLS_STACK_BOTTOM:
+                    break
+                self.type = ETH_TYPE_IP
+                buf = buf[(i + 1) * 4:]
+        try:
+            self.data = self._typesw[self.type](buf)
+            setattr(self, self.data.__class__.__name__.lower(), self.data)
+        except (KeyError, dpkt.UnpackError):
+            self.data = buf
 
     def unpack(self, buf):
         dpkt.Packet.unpack(self, buf)
@@ -76,16 +76,16 @@ class DOT1Q(dpkt.Packet):
 
 # XXX - auto-load Ethernet dispatch table from ETH_TYPE_* definitions
 def __load_types():
-  g = globals()
-  for k, v in g.iteritems():
-    if k.startswith('ETH_TYPE_'):
-      name = k[9:]
-      modname = name.lower()
-      try:
-        mod = __import__(modname, g)
-      except ImportError:
-        continue
-      DOT1Q.set_type(v, getattr(mod, name))
+    g = globals()
+    for k, v in g.iteritems():
+        if k.startswith('ETH_TYPE_'):
+            name = k[9:]
+            modname = name.lower()
+            try:
+                mod = __import__(modname, g)
+            except ImportError:
+                continue
+            DOT1Q.set_type(v, getattr(mod, name))
 
 if not DOT1Q._typesw:
-  __load_types()
+    __load_types()

--- a/dpkt/edp.py
+++ b/dpkt/edp.py
@@ -1,0 +1,20 @@
+"""Extreme Discovery Protocol."""
+
+import dpkt
+import sys
+
+class EDP(dpkt.Packet):
+    __hdr__ = (
+        ('v', 'B', 1),
+        ('res', 'B', 0),
+        ('hlen', 'H', 0),
+        ('sum', 'H', 0),
+        ('seq', 'H', 0),
+        ('mid', 'H', 0),
+        ('mac', '6s', '')
+        )
+    
+    def __str__(self):
+        if not self.sum:
+            self.sum = dpkt.in_cksum(dpkt.Packet.__str__(self))
+        return dpkt.Packet.__str__(self)

--- a/dpkt/ethernet.py
+++ b/dpkt/ethernet.py
@@ -23,9 +23,10 @@ ETH_TYPE_IP = 0x0800  # IP protocol
 ETH_TYPE_ARP = 0x0806  # address resolution protocol
 ETH_TYPE_AOE = 0x88a2  # AoE protocol
 ETH_TYPE_CDP = 0x2000  # Cisco Discovery Protocol
+ETH_TYPE_EDP = 0x00bb  # Extreme Networks Discovery Protocol
 ETH_TYPE_DTP = 0x2004  # Cisco Dynamic Trunking Protocol
 ETH_TYPE_REVARP = 0x8035  # reverse addr resolution protocol
-ETH_TYPE_8021Q = 0x8100  # IEEE 802.1Q VLAN tagging
+ETH_TYPE_DOT1Q = 0x8100  # IEEE 802.1Q VLAN tagging
 ETH_TYPE_IPX = 0x8137  # Internetwork Packet Exchange
 ETH_TYPE_IP6 = 0x86DD  # IPv6 protocol
 ETH_TYPE_PPP = 0x880B  # PPP
@@ -54,16 +55,14 @@ class Ethernet(dpkt.Packet):
     _typesw = {}
 
     def _unpack_data(self, buf):
-        if self.type == ETH_TYPE_8021Q:
-            self.tag, self.type = struct.unpack('>HH', buf[:4])
-            buf = buf[4:]
-        elif self.type == ETH_TYPE_MPLS or self.type == ETH_TYPE_MPLS_MCAST:
+        if self.type == ETH_TYPE_MPLS or \
+          self.type == ETH_TYPE_MPLS_MCAST:
             # XXX - skip labels (max # of labels is undefined, just use 24)
             self.labels = []
             for i in range(24):
-                entry = struct.unpack('>I', buf[i * 4:i * 4 + 4])[0]
-                label = ((entry & MPLS_LABEL_MASK) >> MPLS_LABEL_SHIFT,
-                         (entry & MPLS_QOS_MASK) >> MPLS_QOS_SHIFT,
+                entry = struct.unpack('>I', buf[i*4:i*4+4])[0]
+                label = ((entry & MPLS_LABEL_MASK) >> MPLS_LABEL_SHIFT, \
+                         (entry & MPLS_QOS_MASK) >> MPLS_QOS_SHIFT, \
                          (entry & MPLS_TTL_MASK) >> MPLS_TTL_SHIFT)
                 self.labels.append(label)
                 if entry & MPLS_STACK_BOTTOM:
@@ -81,8 +80,8 @@ class Ethernet(dpkt.Packet):
         if self.type > 1500:
             # Ethernet II
             self._unpack_data(self.data)
-        elif (self.dst.startswith('\x01\x00\x0c\x00\x00') or
-              self.dst.startswith('\x03\x00\x0c\x00\x00')):
+        elif self.dst.startswith('\x01\x00\x0c\x00\x00') or \
+             self.dst.startswith('\x03\x00\x0c\x00\x00'):
             # Cisco ISL
             self.vlan = struct.unpack('>H', self.data[6:8])[0]
             self.unpack(self.data[12:])
@@ -95,7 +94,9 @@ class Ethernet(dpkt.Packet):
             self.dsap, self.ssap, self.ctl = struct.unpack('BBB', self.data[:3])
             if self.data.startswith('\xaa\xaa'):
                 # SNAP
+                self.plen = self.type
                 self.type = struct.unpack('>H', self.data[6:8])[0]
+                self.org = struct.unpack('>I', self.data[2:6])[0] & 0xffffff
                 self._unpack_data(self.data[8:])
             else:
                 # non-SNAP
@@ -106,6 +107,29 @@ class Ethernet(dpkt.Packet):
                     self.data = self.ipx = self._typesw[ETH_TYPE_IPX](self.data[3:])
                 elif dsap == 0x42:  # SAP_STP
                     self.data = self.stp = stp.STP(self.data[3:])
+
+    def pack_hdr(self):
+        try:
+            if hasattr(self, 'org'):
+                return dpkt.Packet.pack_hdr(self) + struct.pack('BB', self.dsap, self.ssap) + \
+                    struct.pack('>b', self.ctl)
+            return dpkt.Packet.pack_hdr(self)
+        except struct.error, e:
+            raise dpkt.PackError(str(e))
+
+    def __len__(self):
+        '''
+        dsap = 1
+        ssap = 1
+        ctl = 1
+        plen = type = 2
+        org = 3
+        '''
+        if hasattr(self, 'dsap'):
+            if hasattr(self, 'org'):
+                return dpkt.Packet.__len__(self) + 8
+            return dpkt.Packet.__len__(self) + 5
+        return dpkt.Packet.__len__(self)
 
     @classmethod
     def set_type(cls, t, pktclass):

--- a/dpkt/igmp.py
+++ b/dpkt/igmp.py
@@ -10,7 +10,7 @@ class IGMP(dpkt.Packet):
         ('type', 'B', 0),
         ('maxresp', 'B', 0),
         ('sum', 'H', 0),
-        ('group', 'I', 0)
+        ('group', '4s', '\x00' * 4)
     )
 
     def __str__(self):


### PR DESCRIPTION
I have been using and making edits to DPKT 1.7 from the Google code page for a couple years. Recently I noticed DPKT now has a Github page, so I've contributing back my changes. This is a pull request for two commits.

The first fixes a bug in igmp.py and is relatively atomic.

The second could not be made any more atomic as supporting 802.1q/p and EDP required the modification of ethernet.py.

Thanks,
Andrew
