### PR TITLE
nanosecond format improvements

### DIFF
--- a/dpkt/pcap.py
+++ b/dpkt/pcap.py
@@ -5,6 +5,7 @@
 import sys
 import time
 import dpkt
+from decimal import Decimal
 
 
 TCPDUMP_MAGIC = 0xa1b2c3d4L
@@ -124,7 +125,7 @@ class Reader(object):
             self.dloff = dltoff[self.__fh.linktype]
         else:
             self.dloff = 0
-        self._divisor = 1E6 if self.__fh.magic in (TCPDUMP_MAGIC, PMUDPCT_MAGIC) else 1E9
+        self._divisor = 1E6 if self.__fh.magic in (TCPDUMP_MAGIC, PMUDPCT_MAGIC) else Decimal(1E9)
         self.snaplen = self.__fh.snaplen
         self.filter = ''
         self.__iter = iter(self)


### PR DESCRIPTION
First, using Python float (IEEE 64-bit double) has insufficient precision for representing nanosecond timestamps; right now float has a precision of 2**-22 s = 238.4 ns, which is much coarser than the precision of high-resolution timestamping equipment. Suggest using decimal.Decimal; numpy.datetime64 would also work but probably not worth the dependency.

Second, support writing in nanosecond format as well as reading.