### PR TITLE
change variable name in rip __len__ function

### DIFF
--- a/dpkt/rip.py
+++ b/dpkt/rip.py
@@ -32,11 +32,11 @@ class RIP(dpkt.Packet):
         self.data = self.rtes = l
 
     def __len__(self):
-        len = self.__hdr_len__
+        n = self.__hdr_len__
         if self.auth:
-            len += len(self.auth)
-        len += sum(map(len, self.rtes))
-        return len
+            n += len(self.auth)
+        n += sum(map(len, self.rtes))
+        return n
 
     def __str__(self):
         auth = ''


### PR DESCRIPTION
the __len__ function in rip.py used a variable named 'len' which, as a
buit-in function, caused problems.