### PR TITLE
Fix ordering of arguments in struct.unpack.

### DIFF
--- a/dpkt/gzip.py
+++ b/dpkt/gzip.py
@@ -70,7 +70,7 @@ class Gzip(dpkt.Packet):
     def unpack(self, buf):
         super(Gzip, self).unpack(buf)
         if self.flags & GZIP_FEXTRA:
-            n = struct.unpack(self.data[:2], '>H')[0]
+            n = struct.unpack('>H', self.data[:2])[0]
             self.extra = GzipExtra(self.data[2:2 + n])
             self.data = self.data[2 + n:]
         if self.flags & GZIP_FNAME:


### PR DESCRIPTION
The order of arguments to the struct.unpack function were incorrect in the gzip
module.  I checked the repo with `git grep struct.unpack` and the rest seems OK.