### PR TITLE
Radiotap extpresent

### DIFF
--- a/dpkt/dpkt.py
+++ b/dpkt/dpkt.py
@@ -48,7 +48,7 @@ class Packet(object):
     self.__hdr__.
 
     Attributes:
-        __hdr__: Packet header should be defined as a list of 
+        __hdr__: Packet header should be defined as a list of
                  (name, structfmt, default) tuples.
         __byte_order__: Byte order, can be set to override the default ('>')
 

--- a/dpkt/radiotap.py
+++ b/dpkt/radiotap.py
@@ -86,7 +86,7 @@ class Radiotap(dpkt.Packet):
         __hdr__: Header fields of Radiotap.
         TODO.
     """
-    
+
     __hdr__ = (
         ('version', 'B', 0),
         ('pad', 'B', 0),


### PR DESCRIPTION
My atheros dongle dongle actually pushes frames with extended present flags. This requires the parser to, at least, skip the extra present flags in order to continue parsing from the right place.

Incidentally this arose another problem: the radiotap header specifications requires each field to be aligned to the start of the packet, and when there are two present flags bitmap, this is even less obvious. In particular the TSFT ended up to be improperly aligned here.

This patch makes the radiotap parser to take care of both there issues, and fixes wrong shift/mask for extended present flag bit.

Since my editor is kind enough to auto-remove trailing spaces, another trivial patch for this shows up also here..
