### PR TITLE
Fixed floating point rounding error in PCAP Writer

### DIFF
--- a/dpkt/pcap.py
+++ b/dpkt/pcap.py
@@ -209,13 +209,15 @@ class Writer(object):
             ts = time.time()
         s = str(pkt)
         n = len(s)
+        sec = int(ts)
+        usec = int(round(ts % 1 * 10 ** self._precision))
         if sys.byteorder == 'little':
-            ph = LEPktHdr(tv_sec=int(ts),
-                          tv_usec=int(round(ts % 1, self._precision) * 10 ** self._precision),
+            ph = LEPktHdr(tv_sec=sec,
+                          tv_usec=usec,
                           caplen=n, len=n)
         else:
-            ph = PktHdr(tv_sec=int(ts),
-                        tv_usec=int(round(ts % 1, self._precision) * 10 ** self._precision),
+            ph = PktHdr(tv_sec=sec,
+                        tv_usec=usec,
                         caplen=n, len=n)
         self.__f.write(str(ph))
         self.__f.write(s)

--- a/dpkt/pcapng.py
+++ b/dpkt/pcapng.py
@@ -349,9 +349,9 @@ class Writer(object):
             self._validate_block('pkt', pkt, EnhancedPacketBlock)
 
             if ts is not None:  # ts as an argument gets precedence
-                ts = int(ts * 1e6)
+                ts = int(round(ts * 1e6))
             elif pkt.ts_high == pkt.ts_low == 0:
-                ts = int(time() * 1e6)
+                ts = int(round(time() * 1e6))
 
             if ts is not None:
                 pkt.ts_high = ts >> 32
@@ -363,7 +363,7 @@ class Writer(object):
         # pkt is a buffer - wrap it into an EPB
         if ts is None:
             ts = time()
-        ts = int(ts * 1e6)  # to int microseconds
+        ts = int(round(ts * 1e6))  # to int microseconds
 
         s = str(pkt)
         n = len(s)


### PR DESCRIPTION
When converting a floating point timestamp into integer seconds and microseconds,
the microsecond component [was being calculated](https://github.com/kbandla/dpkt/blob/master/dpkt/pcap.py#L214) by:
1. Using mod 1 to remove the integral component of the timestamp
2. Using round(x,6) to knock the number down to 6 digits of precision
3. Pushing the microseconds into the integral space by multiplying by 10^6
4. Converting to an integer

By rounding and then performing an additional floating point operation (multiplication),
there is a potential for error to be introduced.

For example, say you start with timestamp 1332502747.5209900094 (2012-03-23 11:39:07AM UTC):
1. mod 1 gives you 0.5209900094
2. round(x,6) gives you 0.520990
3. Multiplying by 10^6 then gives you 520989.99999999994 (should be 520990 but floating point error was introduced)
4. Casting to an int truncates the value to 520989
In the end, the error of 6e-11us in step 3 resulted in a 1us error at the end. That's significant.

To fix this, the rounding just needs to be done after the microseconds are shifted into the integral space, giving the following modified procedure:
1. Using mod 1 to remove the integral component of the timestamp
2. Pushing the microseconds into the integral space by multiplying by 10^6
3. round(x,0) to eliminate the the non-integral (consisting of residual precision from the input and floating point error)
4. Casting to an int truncates the value to 520989
In the end, the error of 6e-11us in step 3 resulted in a 1us error at the end. That's significant.

To fix this, the rounding just needs to be done after the microseconds are shifted into the integral space, giving the following modified procedure:
1. Using mod 1 to remove the integral component of the timestamp
2. Pushing the microseconds into the integral space by multiplying by 10^6
3. round(x,0) to eliminate the the non-integral (consisting of residual precision from the input and floating point error)
4. Converting to an integer

Returning the the previous example, starting with the same input, the new procedure goes as follows:
1. mod 1 gives you 0.5209900094
2. Multiplying by 10^6 then gives you 520990.00939999998
3. round(x,0) gives you 520990.0
4. Casting to an int truncates the value to 520990
We end up with zero error at the end because the 2e-11us error was rounded off