### PR TITLE
Diameter Enhancement: support padding in AVP

### DIFF
--- a/dpkt/diameter.py
+++ b/dpkt/diameter.py
@@ -307,26 +307,32 @@ def test_pack():
         end_id=2345678901,
         )
 
-    avpdict = {
-        'avp_orighost': AVP(
+    # using OrderdDict to keep the order of AVPs.
+    avpdict = OrderedDict()
+    avps = (
+        ('avp_orighost', AVP(
             code=264,
             mandatory_flag=1,
             vendor_flag=0,
-            ),
-        'avp_origrealm': AVP(
-            code=296,
-            mandatory_flag=1,
-            vendor_flag=0,
-            ),
-        'avp_origstateid': AVP(
+            )
+        ),
+        ('avp_origstateid', AVP(
             code=278,
             mandatory_flag=1,
             vendor_flag=0,
-            ),
-        }
+            )
+        ),
+        ('avp_origrealm', AVP(
+            code=296,
+            mandatory_flag=1,
+            vendor_flag=0,
+            )
+        )
+    )
+    avpdict.update(avps)
 
-    avpdict['avp_origstateid'].data = 'yeah'
     avpdict['avp_orighost'].data = 'some00.node00.epc.mnc999.mcc999.3gppnetwork.org'
+    avpdict['avp_origstateid'].data = 'yeah'
     avpdict['avp_origrealm'].data = 'epc.mnc999.mcc999.3gppnetwork.org'
     d.data = [str(v) for k, v in avpdict.iteritems()]
 
@@ -337,7 +343,6 @@ def test_pack():
     assert (d.hop_id == 1234567890)
     assert (d.end_id == 2345678901)
     assert (__s == str(d))
-
 
 def test_unpack():
     """Packing test.
@@ -354,8 +359,6 @@ def test_unpack():
 
     for i in xrange(len(d.avps)):
         avp = d.avps[i]
-        # the difference between avp.len and len(avp) shows
-        # the avp has padding or not.
         if avp.code == avp.avp_codes['ORIGIN_HOST']:
             assert (avp.mandatory_flag == 1)
             assert (avp.vendor_flag == 0)
@@ -377,6 +380,8 @@ def test_unpack():
 
 
 if __name__ == '__main__':
+    from collections import OrderedDict
+
     test_pack()
     test_unpack()
     print 'Tests Successful...'

--- a/dpkt/pcap.py
+++ b/dpkt/pcap.py
@@ -373,3 +373,4 @@ if __name__ == '__main__':
     test_reader()
 
     print 'Tests Successful...'
+

--- a/dpkt/pcap.py
+++ b/dpkt/pcap.py
@@ -373,4 +373,3 @@ if __name__ == '__main__':
     test_reader()
 
     print 'Tests Successful...'
-

--- a/dpkt/sctp.py
+++ b/dpkt/sctp.py
@@ -4,51 +4,36 @@
 
 import dpkt
 import crc32c
-import struct
 
 # Stream Control Transmission Protocol
-# http://tools.ietf.org/html/rfc4960
+# http://tools.ietf.org/html/rfc2960
 
 # Chunk Types
-CHUNK_TYPE_DATA = 0
-CHUNK_TYPE_INIT = 1
-CHUNK_TYPE_INIT_ACK = 2
-CHUNK_TYPE_SACK = 3
-CHUNK_TYPE_HEARTBEAT = 4
-CHUNK_TYPE_HEARTBEAT_ACK = 5
-CHUNK_TYPE_ABORT = 6
-CHUNK_TYPE_SHUTDOWN = 7
-CHUNK_TYPE_SHUTDOWN_ACK = 8
-CHUNK_TYPE_ERROR = 9
-CHUNK_TYPE_COOKIE_ECHO = 10
-CHUNK_TYPE_COOKIE_ACK = 11
-CHUNK_TYPE_ECNE = 12
-CHUNK_TYPE_CWR = 13
-CHUNK_TYPE_SHUTDOWN_COMPLETE = 14
-
-# Chunk Error Cause Codes
-CHUNK_ERR_INVALID_ID = 1
-CHUNK_ERR_MISS_MAND_PARAM = 2
-CHUNK_ERR_STALE_COOKIE = 3
-CHUNK_ERR_OUT_OF_RESOURCE = 4
-CHUNK_ERR_UNRESOLV_ADDR = 5
-CHUNK_ERR_UNRECOG_TYPE = 6
-CHUNK_ERR_INVALID_MAND_PARAM = 7
-CHUNK_ERR_UNRECOG_PARAM = 8
-CHUNK_ERR_NO_USER_DATA = 9
-CHUNK_ERR_COOKIE_WHILE_SHUT = 10
-CHUNK_ERR_RESTART_ASSOC = 11
-CHUNK_ERR_USER_INIT_ABORT = 12
-CHUNK_ERR_PROTO_VIOLATION = 13
+DATA = 0
+INIT = 1
+INIT_ACK = 2
+SACK = 3
+HEARTBEAT = 4
+HEARTBEAT_ACK = 5
+ABORT = 6
+SHUTDOWN = 7
+SHUTDOWN_ACK = 8
+ERROR = 9
+COOKIE_ECHO = 10
+COOKIE_ACK = 11
+ECNE = 12
+CWR = 13
+SHUTDOWN_COMPLETE = 14
 
 
 class SCTP(dpkt.Packet):
     """Stream Control Transmission Protocol.
-    This Class handles only common header in SCTP.
-    Upper layers should be handled by Chunk* Classes below.
+    TODO: Longer class information....
     Attributes:
-        __hdr__: Common Header fields of SCTP.
+        __hdr__: Header fields of SCTP.
+        TODO.
     """
+    
     __hdr__ = (
         ('sport', 'H', 0),
         ('dport', 'H', 0),
@@ -58,11 +43,9 @@ class SCTP(dpkt.Packet):
 
     def unpack(self, buf):
         dpkt.Packet.unpack(self, buf)
-        if self.data:
-            self.ctype = struct.unpack('B', self.data[0:1])[0]
         l = []
         while self.data:
-            chunk = CHUNK_TYPES_DICT.get(self.ctype, Chunk)(self.data)
+            chunk = Chunk(self.data)
             l.append(chunk)
             self.data = self.data[len(chunk):]
         self.data = self.chunks = l
@@ -81,651 +64,39 @@ class SCTP(dpkt.Packet):
 
 
 class Chunk(dpkt.Packet):
-    """SCTP General Chunk.
-    This Class is used as the SuperClass of all types of chunk and
-    as the Class of some chunks whose type is unknown or not implemented.
-    This only handles the three common part of Generic Chunk Headers;
-     - Chunk type
-     - Chunk flags
-     - Chunk length
-    Attributes:
-        __hdr__: Generic Chunk Header fields common in all types.
-    """
     __hdr__ = (
-        ('type', 'B', CHUNK_TYPE_INIT),
+        ('type', 'B', INIT),
         ('flags', 'B', 0),
         ('len', 'H', 0)
     )
 
-
-class ChunkData(Chunk):
-    """SCTP DATA Chunk.
-    This Class is to handle the 'DATA' type of SCTP Chunk.
-    Supported fields are;
-     - Chunk type
-     - Chunk flags
-     - Chunk length
-     - Transmission sequence number
-     - Stream identifier
-     - Stream sequence number
-     - Payload protocol identifier
-    Attributes:
-        __hdr__: Generic Chunk Header fields of SCTP.
-        __hdr_spec__: Type-specific Chunk Header fields of SCTP.
-    """
-    __hdr_spec__ = (
-        ('tsn', 'I', 0),
-        ('stream_id', 'H', 0),
-        ('stream_seq', 'H', 0),
-        ('proto_id', 'I', 0)
-    )
-    __hdr__ = Chunk.__hdr__ + __hdr_spec__
+    def unpack(self, buf):
+        dpkt.Packet.unpack(self, buf)
+        self.data = self.data[:self.len - self.__hdr_len__]
 
 
-class ChunkInit(Chunk):
-    """SCTP INIT Chunk.
-    This Class is to handle the 'INIT' type of SCTP Chunk.
-    Supported fields are;
-     - Chunk type
-     - Chunk flags
-     - Chunk length
-     - Initiate tag
-     - Advertised receiver window credit
-     - Number of outbound stream
-     - Number of inbound stream
-     - Initial TSN
-    Attributes:
-        __hdr__: Generic Chunk Header fields of SCTP.
-        __hdr_spec__: Type-specific Chunk Header fields of SCTP.
-    """
-    __hdr_spec__ = (
-        ('init_tag', 'I', 0),
-        ('a_rwnd', 'I', 0),
-        ('num_os', 'H', 0),
-        ('num_is', 'H', 0),
-        ('init_tsn', 'I', 0)
-    )
-    __hdr__ = Chunk.__hdr__ + __hdr_spec__
-
-    @property
-    def optionals(self):
-        return self.data
-
-
-class ChunkInitAck(Chunk):
-    """SCTP INIT_ACK Chunk.
-    This Class is to handle the 'INIT_ACK' type of SCTP Chunk.
-    Supported fields are;
-     - Chunk type
-     - Chunk flags
-     - Chunk length
-     - Initiate tag
-     - Advertised receiver window credit
-     - Number of outbound stream
-     - Number of inbound stream
-     - Initial TSN
-     - State cookie parameter
-    Attributes:
-        __hdr__: Generic Chunk Header fields of SCTP.
-        __hdr_spec__: Type-specific Chunk Header fields of SCTP.
-    """
-    __hdr_spec__ = (
-        ('init_tag', 'I', 0),
-        ('a_rwnd', 'I', 0),
-        ('num_os', 'H', 0),
-        ('num_is', 'H', 0),
-        ('init_tsn', 'I', 0),
-        ('cookie_param', 'H', 0),
-        ('param_len', 'H', 0),
-    )
-    __hdr__ = Chunk.__hdr__ + __hdr_spec__
-
-    @property
-    def state_cookie(self):
-        return self.data[:self.param_len]
-
-
-class ChunkSack(Chunk):
-    """SCTP SACK Chunk.
-    This Class is to handle the 'SACK' type of SCTP Chunk.
-    Supported fields are;
-     - Chunk type
-     - Chunk flags
-     - Chunk length
-     - Cumulatice TSN ACK
-     - Advertised receiver window credit
-     - Number of gap acknowledgement blocks
-     - Number of duplicated TSNs
-    Attributes:
-        __hdr__: Generic Chunk Header fields of SCTP.
-        __hdr_spec__: Type-specific Chunk Header fields of SCTP.
-    """
-    __hdr_spec__ = (
-        ('cum_tsn_ack', 'I', 0),
-        ('a_rwnd', 'I', 0),
-        ('num_gap_ack', 'H', 0),
-        ('num_dup_tsn', 'H', 0)
-    )
-    __hdr__ = Chunk.__hdr__ + __hdr_spec__
-
-
-class ChunkHeartbeat(Chunk):
-    """SCTP HEARTBEAT Chunk.
-    This Class is to handle the 'HEARTBEAT' type of SCTP Chunk.
-    Supported fields are;
-     - Chunk type
-     - Chunk flags
-     - Chunk length
-     - Heartbeat info parameter
-        - Heartbeat info parameter type
-        - Heartbeat info parameter length
-        - Heartbeat info parameter information
-    Attributes:
-        __hdr__: Generic Chunk Header fields of SCTP.
-        __hdr_spec__: Type-specific Chunk Header fields of SCTP.
-    """
-    __hdr_spec__ = (
-        ('hb_type', 'H', 0),
-        ('hb_len', 'H', 0),
-    )
-    __hdr__ = Chunk.__hdr__ + __hdr_spec__
-
-    @property
-    def hb_info(self):
-        return self.data
-
-
-class ChunkHeartbeatAck(Chunk):
-    """SCTP HEARTBEAT_ACK Chunk.
-    This Class is to handle the 'HEARTBEAT_ACK' type of SCTP Chunk.
-    Supported fields are;
-     - Chunk type
-     - Chunk flags
-     - Chunk length
-     - Heartbeat info parameter
-        - Heartbeat info parameter type
-        - Heartbeat info parameter length
-        - Heartbeat info parameter information
-    Attributes:
-        __hdr__: Generic Chunk Header fields of SCTP.
-        __hdr_spec__: Type-specific Chunk Header fields of SCTP.
-    """
-    __hdr_spec__ = (
-        ('hb_type', 'H', 0),
-        ('hb_len', 'H', 0),
-    )
-    __hdr__ = Chunk.__hdr__ + __hdr_spec__
-
-    @property
-    def hb_info(self):
-        return self.data
-
-
-class ChunkAbort(Chunk):
-    """SCTP ABORT Chunk.
-    This Class is to handle the 'ABORT' type of SCTP Chunk.
-    Supported fields are;
-     - Chunk type
-     - Chunk flags
-     - Chunk length
-    Attributes:
-        __hdr__: Generic Chunk Header fields of SCTP.
-        __hdr_spec__: Type-specific Chunk Header fields of SCTP.
-    """
-    __hdr__ = Chunk.__hdr__
-
-
-class ChunkShutdown(Chunk):
-    """SCTP SHUTDOWN Chunk.
-    This Class is to handle the 'SHUTDOWN' type of SCTP Chunk.
-    Supported fields are;
-     - Chunk type
-     - Chunk flags
-     - Chunk length
-     - Cumulatice TSN ACK
-    Attributes:
-        __hdr__: Generic Chunk Header fields of SCTP.
-        __hdr_spec__: Type-specific Chunk Header fields of SCTP.
-    """
-    __hdr_spec__ = (
-        ('cum_tsn_ack', 'I', 0),
-    )
-    __hdr__ = Chunk.__hdr__ + __hdr_spec__
-
-
-class ChunkShutdownAck(Chunk):
-    """SCTP SHUTDOWN_ACK Chunk.
-    This Class is to handle the 'SHUTDOWN_ACK' type of SCTP Chunk.
-    Supported fields are;
-     - Chunk type
-     - Chunk flags
-     - Chunk length
-    Attributes:
-        __hdr__: Generic Chunk Header fields of SCTP.
-        __hdr_spec__: Type-specific Chunk Header fields of SCTP.
-    """
-    __hdr__ = Chunk.__hdr__
-
-
-class ChunkError(Chunk):
-    """SCTP ERROR Chunk.
-    *** IMPLEMENTATION NOT COMPLETE ***
-    This Class is to handle the 'ERROR' type of SCTP Chunk.
-    Supported fields are;
-     - Chunk type
-     - Chunk flags
-     - Chunk length
-     - Cause code
-     - Cause length
-     - Cause-specific information
-        - Invalid Stream Identifier
-        - Missing Mandatory Parameter
-        - Stale Cookie Error
-        - Out of Resource
-        - Unresolvable Address
-        - Unrecognized Chunk Type
-        - Invalid Mandatory Parameter
-        - Unrecognized Parameters
-        - No User Data
-        - Cookie Received While Shutting Down
-        - Restart of an Association with New Addresses
-        - User Initiated Abort
-        - Protocol Violation
-    Attributes:
-        __hdr__: Generic Chunk Header fields of SCTP.
-        __hdr_spec__: Type-specific Chunk Header fields of SCTP.
-    """
-    __hdr_spec__ = (
-        ('cause_code', 'H', 0),
-        ('cause_len', 'H', 0),
-    )
-    __hdr__ = Chunk.__hdr__ + __hdr_spec__
-
-    @property
-    def invalid_id(self):
-        if self.cause_code == CHUNK_ERR_INVALID_ID:
-            return self.data[:self.len - self.__hdr_len__ -6]
-
-    @property
-    def num_miss_param(self):
-        if self.cause_code == CHUNK_ERR_MISS_MAND_PARAM:
-            return self.data[:4]
-
-    @property
-    def miss_param_types(self):
-        if self.cause_code == CHUNK_ERR_MISS_MAND_PARAM:
-            return [self.data[4*i:4*i+2] for i in xrange(1, self.num_miss_param + 1)]
-
-    @property
-    def measure_stale(self):
-        if self.cause_code == CHUNK_ERR_STALE_COOKIE:
-            return self.data
-
-    @property
-    def unresolv_addr(self):
-        if self.cause_code == CHUNK_ERR_UNRESOLV_ADDR:
-            return self.data
-    @property
-    def unrecog_chunk(self):
-        if self.cause_code == CHUNK_ERR_UNRECOG_TYPE:
-            return self.data
-
-    @property
-    def unrecog_param(self):
-        if self.cause_code == CHUNK_ERR_UNRECOG_PARAM:
-            return self.data
-
-    @property
-    def no_data_tsn(self):
-        if self.cause_code == CHUNK_ERR_NO_USER_DATA:
-            return self.data
-
-    @property
-    def new_addr_tlvs(self):
-        if self.cause_code == CHUNK_ERR_RESTART_ASSOC:
-            return self.data
-
-    @property
-    def abort_reason(self):
-        if self.cause_code == CHUNK_ERR_USER_INIT_ABORT:
-            return self.data
-
-    @property
-    def additional_info(self):
-        if self.cause_code == CHUNK_ERR_PROTO_VIOLATION:
-            return self.data
-
-
-class ChunkCookieEcho(Chunk):
-    """SCTP COOKIE_ECHO Chunk.
-    This Class is to handle the 'COOKIE_ECHO' type of SCTP Chunk.
-    Supported fields are;
-     - Chunk type
-     - Chunk flags
-     - Chunk length
-     - Cookie
-    Attributes:
-        __hdr__: Generic Chunk Header fields of SCTP.
-        __hdr_spec__: Type-specific Chunk Header fields of SCTP.
-    """
-    __hdr__ = Chunk.__hdr__
-
-    @property
-    def cookie(self):
-        return self.data
-
-
-class ChunkCookieAck(Chunk):
-    """SCTP COOKIE_ACK Chunk.
-    This Class is to handle the 'COOKIE_ACK' type of SCTP Chunk.
-    Supported fields are;
-     - Chunk type
-     - Chunk flags
-     - Chunk length
-    Attributes:
-        __hdr__: Generic Chunk Header fields of SCTP.
-        __hdr_spec__: Type-specific Chunk Header fields of SCTP.
-    """
-    __hdr__ = Chunk.__hdr__
-
-
-class ChunkECNE(Chunk):
-    """SCTP ECNE(ECN-Echo) Chunk.
-    This Class is to handle the 'ECNE' type of SCTP Chunk.
-    Supported fields are;
-     - Chunk type
-     - Chunk flags
-     - Chunk length
-     - Lowest TSN number
-    Attributes:
-        __hdr__: Generic Chunk Header fields of SCTP.
-        __hdr_spec__: Type-specific Chunk Header fields of SCTP.
-    """
-    __hdr_spec__ = (
-        ('lowest_tsn', 'I', 0),
-    )
-    __hdr__ = Chunk.__hdr__ + __hdr_spec__
-
-
-class ChunkCWR(Chunk):
-    """SCTP CWR(Congestion Window Reduced) Chunk.
-    This Class is to handle the 'CWR' type of SCTP Chunk.
-    Supported fields are;
-     - Chunk type
-     - Chunk flags
-     - Chunk length
-     - Lowest TSN number
-    Attributes:
-        __hdr__: Generic Chunk Header fields of SCTP.
-        __hdr_spec__: Type-specific Chunk Header fields of SCTP.
-    """
-    __hdr_spec__ = (
-        ('lowest_tsn', 'I', 0),
-    )
-    __hdr__ = Chunk.__hdr__ + __hdr_spec__
-
-
-class ChunkShutdownComplete(Chunk):
-    """SCTP SHUTDOWN_COMPLETE Chunk.
-    This Class is to handle the 'SHUTDOWN_COMPLETE' type of SCTP Chunk.
-    Supported fields are;
-     - Chunk type
-     - Chunk flags
-     - Chunk length
-    Attributes:
-        __hdr__: Generic Chunk Header fields of SCTP.
-        __hdr_spec__: Type-specific Chunk Header fields of SCTP.
-    """
-    __hdr__ = Chunk.__hdr__
-
-
-# Dictionary to call appropriate subclass from superclass.
-CHUNK_TYPES_DICT = {
-    CHUNK_TYPE_DATA: ChunkData,
-    CHUNK_TYPE_INIT: ChunkInit,
-    CHUNK_TYPE_INIT_ACK: ChunkInitAck,
-    CHUNK_TYPE_SACK: ChunkSack,
-    CHUNK_TYPE_HEARTBEAT: ChunkHeartbeat,
-    CHUNK_TYPE_HEARTBEAT_ACK: ChunkHeartbeatAck,
-    CHUNK_TYPE_ABORT: ChunkAbort,
-    CHUNK_TYPE_SHUTDOWN: ChunkShutdown,
-    CHUNK_TYPE_SHUTDOWN_ACK: ChunkShutdownAck,
-    CHUNK_TYPE_ERROR: ChunkError,
-    CHUNK_TYPE_COOKIE_ECHO: ChunkCookieEcho,
-    CHUNK_TYPE_COOKIE_ACK: ChunkCookieAck,
-    CHUNK_TYPE_ECNE: ChunkECNE,
-    CHUNK_TYPE_CWR: ChunkCWR,
-    CHUNK_TYPE_SHUTDOWN_COMPLETE: ChunkShutdownComplete
-}
-
-
-test_bytearr = {
-    'DATA': b'\x0f\xe4\x0f\x1c\xceU\xce\x8f\xf5@\x8bv\x00\x03\x01\xcc\xbb{\x0f\x9c\x00\x00\x00\x00\x00\x00\x00\x00\xde\xad\xbe\xef',
-    'INIT': b'\x0f\xe4\x0f\x1c\x00\x00\x00\x00\x9fx\xa7\x04\x01\x00\x00\x14\xbb{\x0f\x9c\x00\x00\xfa\x00\x00\n\x00\n\xbb{\x0f\x9c',
-    'INIT_ACK': b'\x0f\x1c\x0f\xe4\xbb{\x0f\x9c\xf7\x06\xbds\x02\x00\x01\xc4\xceU\xce\x8f\x00\x00\xfa'
-                 '\x00\x00\n\x00\n\xceU\xce\x8f\x00\x07\x01\xb0\xbb{\x0f\x9c\x00\x00\xfa\x00\x00\n\x00'
-                 '\x00\xbb{\x0f\x9c\x00\x00\x00\x00\x0f\xe4\x00\x00\x01\x00\x00\x00\x04\x00\x00\x00\x01'
-                 '\x01\x01\n\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-                 '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-                 '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-                 '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-                 '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-                 '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-                 '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-                 '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xceU\xce\x8f\x00\x00\xfa\x00\x00\n'
-                 '\x00\x00\xceU\xce\x8f\x0f\x1c\x00\x00\x01\x00\x00\x00\x04\x00\x00\x00\x01\x01\x01\x14'
-                 '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-                 '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-                 '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-                 '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-                 '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-                 '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-                 '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-                 '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-                 '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00O9\xd8XO:\xc2\xb8',
-    'SACK': b'\x0f\x1c\x0f\xe4\xbb{\x0f\x9cy\x94\x91)\x03\x00\x00\x10\xbb{\x0f\x9c\x00\x00\xfa\x00\x00\x00\x00\x00',
-    'HEARTBEAT': b'\x0bY\x0bY\x00\x00\x0ePS\xc3\x05_\x04\x00\x00\x18\x00\x01\x00\x14@\xe4K\x92\n\x1c\x06,\x1bf\xaf~\xde\xad\x00\x00',
-    'HEARTBEAT_ACK': b'\x0bY\x0bY\rS\xe6\xfe\x8c\x8e\x07F\x05\x00\x00\x18\x00\x01\x00\x14@\xe4K\x92\n\x1c\x06,\x1bf\xaf~\xbe\xef\x00\x00',
-    'ABORT': b'0909\xbee\xa7\xef}\xc1\xb2\xfc\x06\x00\x00\x04',
-    'COOKIE_ECHO': b'\x0f\xe4\x0f\x1c\xceU\xce\x8f\x99j\x08\xa6\n\x00\x01\xb0\xbb{\x0f\x9c\x00\x00\xfa\x00'
-                    '\x00\n\x00\x00\xbb{\x0f\x9c\x00\x00\x00\x00\x0f\xe4\x00\x00\x01\x00\x00\x00\x04\x00'
-                    '\x00\x00\x01\x01\x01\n\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-                    '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-                    '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-                    '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-                    '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-                    '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-                    '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-                    '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-                    '\x00\x00\xceU\xce\x8f\x00\x00\xfa\x00\x00\n\x00\x00\xceU\xce\x8f\x0f\x1c\x00\x00\x01'
-                    '\x00\x00\x00\x04\x00\x00\x00\x01\x01\x01\x14\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-                    '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-                    '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-                    '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-                    '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-                    '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-                    '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-                    '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-                    '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
-                    '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00O9\xd8XO:\xc2\xb8',
-    'COOKIE_ACK': b'\x0f\x1c\x0f\xe4\xbb{\x0f\x9c!B\xfaa\x0b\x00\x00\x04',
-    'ERROR_01': b'0909\xde\xad\xbe\xef\xde\xad\xbe\xef\t\x00\x00\x10\x00\x01\x00\x08\x00\x99\x00\x00',
-    'SHUTDOWN': b'\x0f\x1c\x0f\xe4\xbb{\x0f\x9ca\x1d\xedW\x07\x00\x00\x08\xbb{\x0f\x9d',
-    'SHUTDOWN_ACK': b'\x0f\xe4\x0f\x1c\xceU\xce\x8f<\xd9\xc2\x82\x08\x00\x00\x04',
-    'ECNE': b'0909\xde\xad\xbe\xef\xde\xad\xbe\xef\x0c\x00\x00\x08\xde\xad\xbe\xef',
-    'CWR': b'0909\xde\xad\xbe\xef\xde\xad\xbe\xef\r\x00\x00\x08\xde\xad\xbe\xef',
-    'SHUTDOWN_COMPLETE': b'\x0f\x1c\x0f\xe4\xbb{\x0f\x9cj\xd9\x9d\xc7\x0e\x00\x00\x04',
-}
+__s = '\x80\x44\x00\x50\x00\x00\x00\x00\x30\xba\xef\x54\x01\x00\x00\x3c\x3b\xb9\x9c\x46\x00\x01\xa0\x00\x00\x0a\xff\xff\x2b\x2d\x7e\xb2\x00\x05\x00\x08\x9b\xe6\x18\x9b\x00\x05\x00\x08\x9b\xe6\x18\x9c\x00\x0c\x00\x06\x00\x05\x00\x00\x80\x00\x00\x04\xc0\x00\x00\x04\xc0\x06\x00\x08\x00\x00\x00\x00'
 
 
 def test_sctp_pack():
-    for k, v in test_bytearr.items():
-        sctp = SCTP(v)
-        assert (v == str(sctp))
-        sctp.sum = 0
-        print 'Successfully done packing %s' % k
+    sctp = SCTP(__s)
+    assert (__s == str(sctp))
+    sctp.sum = 0
+    assert (__s == str(sctp))
+
 
 def test_sctp_unpack():
-    import binascii
-    for k, v in test_bytearr.items():
-        sctp = SCTP(v)
-        sctpchunk = sctp.chunks[0]
-        if isinstance(sctpchunk, ChunkData):
-            assert (sctp.sport == 4068)
-            assert (sctp.dport == 3868)
-            assert (sctpchunk.type == 0)
-            assert (sctpchunk.flags == 3)
-            assert (sctpchunk.len == 460)
-            assert (sctpchunk.tsn == 3145404316)
-            assert (sctpchunk.stream_id == 0)
-            assert (sctpchunk.stream_seq == 0)
-            assert (sctpchunk.proto_id == 0)
-            assert (binascii.hexlify(sctpchunk.data) == 'deadbeef')
-        elif isinstance(sctpchunk, ChunkInit):
-            assert (sctp.sport == 4068)
-            assert (sctp.dport == 3868)
-            assert (sctpchunk.type == 1)
-            assert (sctpchunk.flags == 0)
-            assert (sctpchunk.len == 20)
-            assert (sctpchunk.init_tag == 3145404316)
-            assert (sctpchunk.a_rwnd == 64000)
-            assert (sctpchunk.num_os == 10)
-            assert (sctpchunk.num_is == 10)
-            assert (sctpchunk.init_tsn == 3145404316)
-        elif isinstance(sctpchunk, ChunkInitAck):
-            assert (sctp.sport == 3868)
-            assert (sctp.dport == 4068)
-            assert (sctpchunk.type == 2)
-            assert (sctpchunk.flags == 0)
-            assert (sctpchunk.len == 452)
-            assert (sctpchunk.init_tag == 3461729935)
-            assert (sctpchunk.a_rwnd == 64000)
-            assert (sctpchunk.num_os == 10)
-            assert (sctpchunk.num_is == 10)
-            assert (sctpchunk.init_tsn == 3461729935)
-            assert (sctpchunk.cookie_param == 7)
-            assert (sctpchunk.param_len == 432)
-            assert (binascii.hexlify(sctpchunk.state_cookie) == (
-                'bb7b0f9c0000fa00000a0000bb7b0f9c000000000fe4000001000000040000000101010a0000000000'
-                '0000000000000000000000000000000000000000000000000000000000000000000000000000000000'
-                '0000000000000000000000000000000000000000000000000000000000000000000000000000000000'
-                '0000000000000000000000000000000000000000000000000000000000000000000000000000000000'
-                '000000000000000000000000000000000000000000000000000000000000000000000000ce55ce8f00'
-                '00fa00000a0000ce55ce8f0f1c00000100000004000000010101140000000000000000000000000000'
-                '0000000000000000000000000000000000000000000000000000000000000000000000000000000000'
-                '0000000000000000000000000000000000000000000000000000000000000000000000000000000000'
-                '0000000000000000000000000000000000000000000000000000000000000000000000000000000000'
-                '0000000000000000000000000000000000000000000000000000000000000000000000000000000000'
-                '000000000000000000004f39d8584f3ac2b8'
-                )
-            )
-        elif isinstance(sctpchunk, ChunkSack):
-            assert (sctp.sport == 3868)
-            assert (sctp.dport == 4068)
-            assert (sctpchunk.type == 3)
-            assert (sctpchunk.flags == 0)
-            assert (sctpchunk.len == 16)
-            assert (sctpchunk.cum_tsn_ack == 3145404316)
-            assert (sctpchunk.a_rwnd == 64000)
-            assert (sctpchunk.num_gap_ack == 0)
-            assert (sctpchunk.num_dup_tsn == 0)
-        elif isinstance(sctpchunk, ChunkHeartbeat):
-            assert (sctp.sport == 2905)
-            assert (sctp.dport == 2905)
-            assert (sctpchunk.type == 4)
-            assert (sctpchunk.flags == 0)
-            assert (sctpchunk.len == 24)
-            assert (sctpchunk.hb_type == 1)
-            assert (sctpchunk.hb_len == 20)
-            assert (binascii.hexlify(sctpchunk.hb_info) == '40e44b920a1c062c1b66af7edead0000')
-        elif isinstance(sctpchunk, ChunkHeartbeatAck):
-            assert (sctp.sport == 2905)
-            assert (sctp.dport == 2905)
-            assert (sctpchunk.type == 5)
-            assert (sctpchunk.flags == 0)
-            assert (sctpchunk.len == 24)
-            assert (sctpchunk.hb_type == 1)
-            assert (sctpchunk.hb_len == 20)
-            assert (binascii.hexlify(sctpchunk.hb_info) == '40e44b920a1c062c1b66af7ebeef0000')
-        elif isinstance(sctpchunk, ChunkAbort):
-            assert (sctp.sport == 12345)
-            assert (sctp.dport == 12345)
-            assert (sctpchunk.type == 6)
-            assert (sctpchunk.flags == 0)
-            assert (sctpchunk.len == 4)
-        elif isinstance(sctpchunk, ChunkShutdown):
-            assert (sctp.sport == 3868)
-            assert (sctp.dport == 4068)
-            assert (sctpchunk.type == 7)
-            assert (sctpchunk.flags == 0)
-            assert (sctpchunk.len == 8)
-            assert (sctpchunk.cum_tsn_ack == 3145404317)
-        elif isinstance(sctpchunk, ChunkShutdownAck):
-            assert (sctp.sport == 4068)
-            assert (sctp.dport == 3868)
-            assert (sctpchunk.type == 8)
-            assert (sctpchunk.flags == 0)
-            assert (sctpchunk.len == 4)
-        elif isinstance(sctpchunk, ChunkError):
-            assert (sctp.sport == 12345)
-            assert (sctp.dport == 12345)
-            assert (sctpchunk.type == 9)
-            assert (sctpchunk.flags == 0)
-            assert (sctpchunk.len == 16)
-            assert (sctpchunk.cause_code == 1)
-            assert (sctpchunk.cause_len == 8)
-            assert ((struct.unpack('H', sctpchunk.invalid_id)[0] >> 8) == 153)
-        elif isinstance(sctpchunk, ChunkCookieEcho):
-            assert (sctp.sport == 4068)
-            assert (sctp.dport == 3868)
-            assert (sctpchunk.type == 10)
-            assert (sctpchunk.flags == 0)
-            assert (sctpchunk.len == 432)
-            assert (binascii.hexlify(sctpchunk.cookie) == (
-                'bb7b0f9c0000fa00000a0000bb7b0f9c000000000fe4000001000000040000000101010a0000000000'
-                '0000000000000000000000000000000000000000000000000000000000000000000000000000000000'
-                '0000000000000000000000000000000000000000000000000000000000000000000000000000000000'
-                '0000000000000000000000000000000000000000000000000000000000000000000000000000000000'
-                '000000000000000000000000000000000000000000000000000000000000000000000000ce55ce8f00'
-                '00fa00000a0000ce55ce8f0f1c00000100000004000000010101140000000000000000000000000000'
-                '0000000000000000000000000000000000000000000000000000000000000000000000000000000000'
-                '0000000000000000000000000000000000000000000000000000000000000000000000000000000000'
-                '0000000000000000000000000000000000000000000000000000000000000000000000000000000000'
-                '0000000000000000000000000000000000000000000000000000000000000000000000000000000000'
-                '000000000000000000004f39d8584f3ac2b8'
-                )
-            )
-        elif isinstance(sctpchunk, ChunkCookieAck):
-            assert (sctp.sport == 3868)
-            assert (sctp.dport == 4068)
-            assert (sctpchunk.type == 11)
-            assert (sctpchunk.flags == 0)
-            assert (sctpchunk.len == 4)
-        elif isinstance(sctpchunk, ChunkECNE):
-            assert (sctp.sport == 12345)
-            assert (sctp.dport == 12345)
-            assert (sctpchunk.type == 12)
-            assert (sctpchunk.flags == 0)
-            assert (sctpchunk.len == 8)
-            assert (sctpchunk.lowest_tsn == 3735928559)
-        elif isinstance(sctpchunk, ChunkCWR):
-            assert (sctp.sport == 12345)
-            assert (sctp.dport == 12345)
-            assert (sctpchunk.type == 13)
-            assert (sctpchunk.flags == 0)
-            assert (sctpchunk.len == 8)
-            assert (sctpchunk.lowest_tsn == 3735928559)
-        elif isinstance(sctpchunk, ChunkShutdownComplete):
-            assert (sctp.sport == 3868)
-            assert (sctp.dport == 4068)
-            assert (sctpchunk.type == 14)
-            assert (sctpchunk.flags == 0)
-            assert (sctpchunk.len == 4)
-        print 'Successfully done unpacking %s' % k
+    sctp = SCTP(__s)
+    assert (sctp.sport == 32836)
+    assert (sctp.dport == 80)
+    assert (len(sctp.chunks) == 1)
+    assert (len(sctp) == 72)
+    chunk = sctp.chunks[0]
+    assert (chunk.type == INIT)
+    assert (chunk.len == 60)
 
 
 if __name__ == '__main__':
     test_sctp_pack()
     test_sctp_unpack()
     print 'Tests Successful...'
-

--- a/dpkt/sctp.py
+++ b/dpkt/sctp.py
@@ -4,38 +4,51 @@
 
 import dpkt
 import crc32c
+import struct
 
 # Stream Control Transmission Protocol
-# http://tools.ietf.org/html/rfc2960
+# http://tools.ietf.org/html/rfc4960
 
 # Chunk Types
-DATA = 0
-INIT = 1
-INIT_ACK = 2
-SACK = 3
-HEARTBEAT = 4
-HEARTBEAT_ACK = 5
-ABORT = 6
-SHUTDOWN = 7
-SHUTDOWN_ACK = 8
-ERROR = 9
-COOKIE_ECHO = 10
-COOKIE_ACK = 11
-ECNE = 12
-CWR = 13
-SHUTDOWN_COMPLETE = 14
+CHUNK_TYPE_DATA = 0
+CHUNK_TYPE_INIT = 1
+CHUNK_TYPE_INIT_ACK = 2
+CHUNK_TYPE_SACK = 3
+CHUNK_TYPE_HEARTBEAT = 4
+CHUNK_TYPE_HEARTBEAT_ACK = 5
+CHUNK_TYPE_ABORT = 6
+CHUNK_TYPE_SHUTDOWN = 7
+CHUNK_TYPE_SHUTDOWN_ACK = 8
+CHUNK_TYPE_ERROR = 9
+CHUNK_TYPE_COOKIE_ECHO = 10
+CHUNK_TYPE_COOKIE_ACK = 11
+CHUNK_TYPE_ECNE = 12
+CHUNK_TYPE_CWR = 13
+CHUNK_TYPE_SHUTDOWN_COMPLETE = 14
+
+# Chunk Error Cause Codes
+CHUNK_ERR_INVALID_ID = 1
+CHUNK_ERR_MISS_MAND_PARAM = 2
+CHUNK_ERR_STALE_COOKIE = 3
+CHUNK_ERR_OUT_OF_RESOURCE = 4
+CHUNK_ERR_UNRESOLV_ADDR = 5
+CHUNK_ERR_UNRECOG_TYPE = 6
+CHUNK_ERR_INVALID_MAND_PARAM = 7
+CHUNK_ERR_UNRECOG_PARAM = 8
+CHUNK_ERR_NO_USER_DATA = 9
+CHUNK_ERR_COOKIE_WHILE_SHUT = 10
+CHUNK_ERR_RESTART_ASSOC = 11
+CHUNK_ERR_USER_INIT_ABORT = 12
+CHUNK_ERR_PROTO_VIOLATION = 13
 
 
 class SCTP(dpkt.Packet):
     """Stream Control Transmission Protocol.
-
-    TODO: Longer class information....
-
+    This Class handles only common header in SCTP.
+    Upper layers should be handled by Chunk* Classes below.
     Attributes:
-        __hdr__: Header fields of SCTP.
-        TODO.
+        __hdr__: Common Header fields of SCTP.
     """
-    
     __hdr__ = (
         ('sport', 'H', 0),
         ('dport', 'H', 0),
@@ -45,9 +58,11 @@ class SCTP(dpkt.Packet):
 
     def unpack(self, buf):
         dpkt.Packet.unpack(self, buf)
+        if self.data:
+            self.ctype = struct.unpack('B', self.data[0:1])[0]
         l = []
         while self.data:
-            chunk = Chunk(self.data)
+            chunk = CHUNK_TYPES_DICT.get(self.ctype, Chunk)(self.data)
             l.append(chunk)
             self.data = self.data[len(chunk):]
         self.data = self.chunks = l
@@ -66,39 +81,651 @@ class SCTP(dpkt.Packet):
 
 
 class Chunk(dpkt.Packet):
+    """SCTP General Chunk.
+    This Class is used as the SuperClass of all types of chunk and
+    as the Class of some chunks whose type is unknown or not implemented.
+    This only handles the three common part of Generic Chunk Headers;
+     - Chunk type
+     - Chunk flags
+     - Chunk length
+    Attributes:
+        __hdr__: Generic Chunk Header fields common in all types.
+    """
     __hdr__ = (
-        ('type', 'B', INIT),
+        ('type', 'B', CHUNK_TYPE_INIT),
         ('flags', 'B', 0),
         ('len', 'H', 0)
     )
 
-    def unpack(self, buf):
-        dpkt.Packet.unpack(self, buf)
-        self.data = self.data[:self.len - self.__hdr_len__]
+
+class ChunkData(Chunk):
+    """SCTP DATA Chunk.
+    This Class is to handle the 'DATA' type of SCTP Chunk.
+    Supported fields are;
+     - Chunk type
+     - Chunk flags
+     - Chunk length
+     - Transmission sequence number
+     - Stream identifier
+     - Stream sequence number
+     - Payload protocol identifier
+    Attributes:
+        __hdr__: Generic Chunk Header fields of SCTP.
+        __hdr_spec__: Type-specific Chunk Header fields of SCTP.
+    """
+    __hdr_spec__ = (
+        ('tsn', 'I', 0),
+        ('stream_id', 'H', 0),
+        ('stream_seq', 'H', 0),
+        ('proto_id', 'I', 0)
+    )
+    __hdr__ = Chunk.__hdr__ + __hdr_spec__
 
 
-__s = '\x80\x44\x00\x50\x00\x00\x00\x00\x30\xba\xef\x54\x01\x00\x00\x3c\x3b\xb9\x9c\x46\x00\x01\xa0\x00\x00\x0a\xff\xff\x2b\x2d\x7e\xb2\x00\x05\x00\x08\x9b\xe6\x18\x9b\x00\x05\x00\x08\x9b\xe6\x18\x9c\x00\x0c\x00\x06\x00\x05\x00\x00\x80\x00\x00\x04\xc0\x00\x00\x04\xc0\x06\x00\x08\x00\x00\x00\x00'
+class ChunkInit(Chunk):
+    """SCTP INIT Chunk.
+    This Class is to handle the 'INIT' type of SCTP Chunk.
+    Supported fields are;
+     - Chunk type
+     - Chunk flags
+     - Chunk length
+     - Initiate tag
+     - Advertised receiver window credit
+     - Number of outbound stream
+     - Number of inbound stream
+     - Initial TSN
+    Attributes:
+        __hdr__: Generic Chunk Header fields of SCTP.
+        __hdr_spec__: Type-specific Chunk Header fields of SCTP.
+    """
+    __hdr_spec__ = (
+        ('init_tag', 'I', 0),
+        ('a_rwnd', 'I', 0),
+        ('num_os', 'H', 0),
+        ('num_is', 'H', 0),
+        ('init_tsn', 'I', 0)
+    )
+    __hdr__ = Chunk.__hdr__ + __hdr_spec__
+
+    @property
+    def optionals(self):
+        return self.data
+
+
+class ChunkInitAck(Chunk):
+    """SCTP INIT_ACK Chunk.
+    This Class is to handle the 'INIT_ACK' type of SCTP Chunk.
+    Supported fields are;
+     - Chunk type
+     - Chunk flags
+     - Chunk length
+     - Initiate tag
+     - Advertised receiver window credit
+     - Number of outbound stream
+     - Number of inbound stream
+     - Initial TSN
+     - State cookie parameter
+    Attributes:
+        __hdr__: Generic Chunk Header fields of SCTP.
+        __hdr_spec__: Type-specific Chunk Header fields of SCTP.
+    """
+    __hdr_spec__ = (
+        ('init_tag', 'I', 0),
+        ('a_rwnd', 'I', 0),
+        ('num_os', 'H', 0),
+        ('num_is', 'H', 0),
+        ('init_tsn', 'I', 0),
+        ('cookie_param', 'H', 0),
+        ('param_len', 'H', 0),
+    )
+    __hdr__ = Chunk.__hdr__ + __hdr_spec__
+
+    @property
+    def state_cookie(self):
+        return self.data[:self.param_len]
+
+
+class ChunkSack(Chunk):
+    """SCTP SACK Chunk.
+    This Class is to handle the 'SACK' type of SCTP Chunk.
+    Supported fields are;
+     - Chunk type
+     - Chunk flags
+     - Chunk length
+     - Cumulatice TSN ACK
+     - Advertised receiver window credit
+     - Number of gap acknowledgement blocks
+     - Number of duplicated TSNs
+    Attributes:
+        __hdr__: Generic Chunk Header fields of SCTP.
+        __hdr_spec__: Type-specific Chunk Header fields of SCTP.
+    """
+    __hdr_spec__ = (
+        ('cum_tsn_ack', 'I', 0),
+        ('a_rwnd', 'I', 0),
+        ('num_gap_ack', 'H', 0),
+        ('num_dup_tsn', 'H', 0)
+    )
+    __hdr__ = Chunk.__hdr__ + __hdr_spec__
+
+
+class ChunkHeartbeat(Chunk):
+    """SCTP HEARTBEAT Chunk.
+    This Class is to handle the 'HEARTBEAT' type of SCTP Chunk.
+    Supported fields are;
+     - Chunk type
+     - Chunk flags
+     - Chunk length
+     - Heartbeat info parameter
+        - Heartbeat info parameter type
+        - Heartbeat info parameter length
+        - Heartbeat info parameter information
+    Attributes:
+        __hdr__: Generic Chunk Header fields of SCTP.
+        __hdr_spec__: Type-specific Chunk Header fields of SCTP.
+    """
+    __hdr_spec__ = (
+        ('hb_type', 'H', 0),
+        ('hb_len', 'H', 0),
+    )
+    __hdr__ = Chunk.__hdr__ + __hdr_spec__
+
+    @property
+    def hb_info(self):
+        return self.data
+
+
+class ChunkHeartbeatAck(Chunk):
+    """SCTP HEARTBEAT_ACK Chunk.
+    This Class is to handle the 'HEARTBEAT_ACK' type of SCTP Chunk.
+    Supported fields are;
+     - Chunk type
+     - Chunk flags
+     - Chunk length
+     - Heartbeat info parameter
+        - Heartbeat info parameter type
+        - Heartbeat info parameter length
+        - Heartbeat info parameter information
+    Attributes:
+        __hdr__: Generic Chunk Header fields of SCTP.
+        __hdr_spec__: Type-specific Chunk Header fields of SCTP.
+    """
+    __hdr_spec__ = (
+        ('hb_type', 'H', 0),
+        ('hb_len', 'H', 0),
+    )
+    __hdr__ = Chunk.__hdr__ + __hdr_spec__
+
+    @property
+    def hb_info(self):
+        return self.data
+
+
+class ChunkAbort(Chunk):
+    """SCTP ABORT Chunk.
+    This Class is to handle the 'ABORT' type of SCTP Chunk.
+    Supported fields are;
+     - Chunk type
+     - Chunk flags
+     - Chunk length
+    Attributes:
+        __hdr__: Generic Chunk Header fields of SCTP.
+        __hdr_spec__: Type-specific Chunk Header fields of SCTP.
+    """
+    __hdr__ = Chunk.__hdr__
+
+
+class ChunkShutdown(Chunk):
+    """SCTP SHUTDOWN Chunk.
+    This Class is to handle the 'SHUTDOWN' type of SCTP Chunk.
+    Supported fields are;
+     - Chunk type
+     - Chunk flags
+     - Chunk length
+     - Cumulatice TSN ACK
+    Attributes:
+        __hdr__: Generic Chunk Header fields of SCTP.
+        __hdr_spec__: Type-specific Chunk Header fields of SCTP.
+    """
+    __hdr_spec__ = (
+        ('cum_tsn_ack', 'I', 0),
+    )
+    __hdr__ = Chunk.__hdr__ + __hdr_spec__
+
+
+class ChunkShutdownAck(Chunk):
+    """SCTP SHUTDOWN_ACK Chunk.
+    This Class is to handle the 'SHUTDOWN_ACK' type of SCTP Chunk.
+    Supported fields are;
+     - Chunk type
+     - Chunk flags
+     - Chunk length
+    Attributes:
+        __hdr__: Generic Chunk Header fields of SCTP.
+        __hdr_spec__: Type-specific Chunk Header fields of SCTP.
+    """
+    __hdr__ = Chunk.__hdr__
+
+
+class ChunkError(Chunk):
+    """SCTP ERROR Chunk.
+    *** IMPLEMENTATION NOT COMPLETE ***
+    This Class is to handle the 'ERROR' type of SCTP Chunk.
+    Supported fields are;
+     - Chunk type
+     - Chunk flags
+     - Chunk length
+     - Cause code
+     - Cause length
+     - Cause-specific information
+        - Invalid Stream Identifier
+        - Missing Mandatory Parameter
+        - Stale Cookie Error
+        - Out of Resource
+        - Unresolvable Address
+        - Unrecognized Chunk Type
+        - Invalid Mandatory Parameter
+        - Unrecognized Parameters
+        - No User Data
+        - Cookie Received While Shutting Down
+        - Restart of an Association with New Addresses
+        - User Initiated Abort
+        - Protocol Violation
+    Attributes:
+        __hdr__: Generic Chunk Header fields of SCTP.
+        __hdr_spec__: Type-specific Chunk Header fields of SCTP.
+    """
+    __hdr_spec__ = (
+        ('cause_code', 'H', 0),
+        ('cause_len', 'H', 0),
+    )
+    __hdr__ = Chunk.__hdr__ + __hdr_spec__
+
+    @property
+    def invalid_id(self):
+        if self.cause_code == CHUNK_ERR_INVALID_ID:
+            return self.data[:self.len - self.__hdr_len__ -6]
+
+    @property
+    def num_miss_param(self):
+        if self.cause_code == CHUNK_ERR_MISS_MAND_PARAM:
+            return self.data[:4]
+
+    @property
+    def miss_param_types(self):
+        if self.cause_code == CHUNK_ERR_MISS_MAND_PARAM:
+            return [self.data[4*i:4*i+2] for i in xrange(1, self.num_miss_param + 1)]
+
+    @property
+    def measure_stale(self):
+        if self.cause_code == CHUNK_ERR_STALE_COOKIE:
+            return self.data
+
+    @property
+    def unresolv_addr(self):
+        if self.cause_code == CHUNK_ERR_UNRESOLV_ADDR:
+            return self.data
+    @property
+    def unrecog_chunk(self):
+        if self.cause_code == CHUNK_ERR_UNRECOG_TYPE:
+            return self.data
+
+    @property
+    def unrecog_param(self):
+        if self.cause_code == CHUNK_ERR_UNRECOG_PARAM:
+            return self.data
+
+    @property
+    def no_data_tsn(self):
+        if self.cause_code == CHUNK_ERR_NO_USER_DATA:
+            return self.data
+
+    @property
+    def new_addr_tlvs(self):
+        if self.cause_code == CHUNK_ERR_RESTART_ASSOC:
+            return self.data
+
+    @property
+    def abort_reason(self):
+        if self.cause_code == CHUNK_ERR_USER_INIT_ABORT:
+            return self.data
+
+    @property
+    def additional_info(self):
+        if self.cause_code == CHUNK_ERR_PROTO_VIOLATION:
+            return self.data
+
+
+class ChunkCookieEcho(Chunk):
+    """SCTP COOKIE_ECHO Chunk.
+    This Class is to handle the 'COOKIE_ECHO' type of SCTP Chunk.
+    Supported fields are;
+     - Chunk type
+     - Chunk flags
+     - Chunk length
+     - Cookie
+    Attributes:
+        __hdr__: Generic Chunk Header fields of SCTP.
+        __hdr_spec__: Type-specific Chunk Header fields of SCTP.
+    """
+    __hdr__ = Chunk.__hdr__
+
+    @property
+    def cookie(self):
+        return self.data
+
+
+class ChunkCookieAck(Chunk):
+    """SCTP COOKIE_ACK Chunk.
+    This Class is to handle the 'COOKIE_ACK' type of SCTP Chunk.
+    Supported fields are;
+     - Chunk type
+     - Chunk flags
+     - Chunk length
+    Attributes:
+        __hdr__: Generic Chunk Header fields of SCTP.
+        __hdr_spec__: Type-specific Chunk Header fields of SCTP.
+    """
+    __hdr__ = Chunk.__hdr__
+
+
+class ChunkECNE(Chunk):
+    """SCTP ECNE(ECN-Echo) Chunk.
+    This Class is to handle the 'ECNE' type of SCTP Chunk.
+    Supported fields are;
+     - Chunk type
+     - Chunk flags
+     - Chunk length
+     - Lowest TSN number
+    Attributes:
+        __hdr__: Generic Chunk Header fields of SCTP.
+        __hdr_spec__: Type-specific Chunk Header fields of SCTP.
+    """
+    __hdr_spec__ = (
+        ('lowest_tsn', 'I', 0),
+    )
+    __hdr__ = Chunk.__hdr__ + __hdr_spec__
+
+
+class ChunkCWR(Chunk):
+    """SCTP CWR(Congestion Window Reduced) Chunk.
+    This Class is to handle the 'CWR' type of SCTP Chunk.
+    Supported fields are;
+     - Chunk type
+     - Chunk flags
+     - Chunk length
+     - Lowest TSN number
+    Attributes:
+        __hdr__: Generic Chunk Header fields of SCTP.
+        __hdr_spec__: Type-specific Chunk Header fields of SCTP.
+    """
+    __hdr_spec__ = (
+        ('lowest_tsn', 'I', 0),
+    )
+    __hdr__ = Chunk.__hdr__ + __hdr_spec__
+
+
+class ChunkShutdownComplete(Chunk):
+    """SCTP SHUTDOWN_COMPLETE Chunk.
+    This Class is to handle the 'SHUTDOWN_COMPLETE' type of SCTP Chunk.
+    Supported fields are;
+     - Chunk type
+     - Chunk flags
+     - Chunk length
+    Attributes:
+        __hdr__: Generic Chunk Header fields of SCTP.
+        __hdr_spec__: Type-specific Chunk Header fields of SCTP.
+    """
+    __hdr__ = Chunk.__hdr__
+
+
+# Dictionary to call appropriate subclass from superclass.
+CHUNK_TYPES_DICT = {
+    CHUNK_TYPE_DATA: ChunkData,
+    CHUNK_TYPE_INIT: ChunkInit,
+    CHUNK_TYPE_INIT_ACK: ChunkInitAck,
+    CHUNK_TYPE_SACK: ChunkSack,
+    CHUNK_TYPE_HEARTBEAT: ChunkHeartbeat,
+    CHUNK_TYPE_HEARTBEAT_ACK: ChunkHeartbeatAck,
+    CHUNK_TYPE_ABORT: ChunkAbort,
+    CHUNK_TYPE_SHUTDOWN: ChunkShutdown,
+    CHUNK_TYPE_SHUTDOWN_ACK: ChunkShutdownAck,
+    CHUNK_TYPE_ERROR: ChunkError,
+    CHUNK_TYPE_COOKIE_ECHO: ChunkCookieEcho,
+    CHUNK_TYPE_COOKIE_ACK: ChunkCookieAck,
+    CHUNK_TYPE_ECNE: ChunkECNE,
+    CHUNK_TYPE_CWR: ChunkCWR,
+    CHUNK_TYPE_SHUTDOWN_COMPLETE: ChunkShutdownComplete
+}
+
+
+test_bytearr = {
+    'DATA': b'\x0f\xe4\x0f\x1c\xceU\xce\x8f\xf5@\x8bv\x00\x03\x01\xcc\xbb{\x0f\x9c\x00\x00\x00\x00\x00\x00\x00\x00\xde\xad\xbe\xef',
+    'INIT': b'\x0f\xe4\x0f\x1c\x00\x00\x00\x00\x9fx\xa7\x04\x01\x00\x00\x14\xbb{\x0f\x9c\x00\x00\xfa\x00\x00\n\x00\n\xbb{\x0f\x9c',
+    'INIT_ACK': b'\x0f\x1c\x0f\xe4\xbb{\x0f\x9c\xf7\x06\xbds\x02\x00\x01\xc4\xceU\xce\x8f\x00\x00\xfa'
+                 '\x00\x00\n\x00\n\xceU\xce\x8f\x00\x07\x01\xb0\xbb{\x0f\x9c\x00\x00\xfa\x00\x00\n\x00'
+                 '\x00\xbb{\x0f\x9c\x00\x00\x00\x00\x0f\xe4\x00\x00\x01\x00\x00\x00\x04\x00\x00\x00\x01'
+                 '\x01\x01\n\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                 '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                 '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                 '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                 '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                 '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                 '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                 '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xceU\xce\x8f\x00\x00\xfa\x00\x00\n'
+                 '\x00\x00\xceU\xce\x8f\x0f\x1c\x00\x00\x01\x00\x00\x00\x04\x00\x00\x00\x01\x01\x01\x14'
+                 '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                 '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                 '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                 '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                 '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                 '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                 '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                 '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                 '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00O9\xd8XO:\xc2\xb8',
+    'SACK': b'\x0f\x1c\x0f\xe4\xbb{\x0f\x9cy\x94\x91)\x03\x00\x00\x10\xbb{\x0f\x9c\x00\x00\xfa\x00\x00\x00\x00\x00',
+    'HEARTBEAT': b'\x0bY\x0bY\x00\x00\x0ePS\xc3\x05_\x04\x00\x00\x18\x00\x01\x00\x14@\xe4K\x92\n\x1c\x06,\x1bf\xaf~\xde\xad\x00\x00',
+    'HEARTBEAT_ACK': b'\x0bY\x0bY\rS\xe6\xfe\x8c\x8e\x07F\x05\x00\x00\x18\x00\x01\x00\x14@\xe4K\x92\n\x1c\x06,\x1bf\xaf~\xbe\xef\x00\x00',
+    'ABORT': b'0909\xbee\xa7\xef}\xc1\xb2\xfc\x06\x00\x00\x04',
+    'COOKIE_ECHO': b'\x0f\xe4\x0f\x1c\xceU\xce\x8f\x99j\x08\xa6\n\x00\x01\xb0\xbb{\x0f\x9c\x00\x00\xfa\x00'
+                    '\x00\n\x00\x00\xbb{\x0f\x9c\x00\x00\x00\x00\x0f\xe4\x00\x00\x01\x00\x00\x00\x04\x00'
+                    '\x00\x00\x01\x01\x01\n\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                    '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                    '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                    '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                    '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                    '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                    '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                    '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                    '\x00\x00\xceU\xce\x8f\x00\x00\xfa\x00\x00\n\x00\x00\xceU\xce\x8f\x0f\x1c\x00\x00\x01'
+                    '\x00\x00\x00\x04\x00\x00\x00\x01\x01\x01\x14\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                    '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                    '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                    '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                    '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                    '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                    '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                    '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                    '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
+                    '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00O9\xd8XO:\xc2\xb8',
+    'COOKIE_ACK': b'\x0f\x1c\x0f\xe4\xbb{\x0f\x9c!B\xfaa\x0b\x00\x00\x04',
+    'ERROR_01': b'0909\xde\xad\xbe\xef\xde\xad\xbe\xef\t\x00\x00\x10\x00\x01\x00\x08\x00\x99\x00\x00',
+    'SHUTDOWN': b'\x0f\x1c\x0f\xe4\xbb{\x0f\x9ca\x1d\xedW\x07\x00\x00\x08\xbb{\x0f\x9d',
+    'SHUTDOWN_ACK': b'\x0f\xe4\x0f\x1c\xceU\xce\x8f<\xd9\xc2\x82\x08\x00\x00\x04',
+    'ECNE': b'0909\xde\xad\xbe\xef\xde\xad\xbe\xef\x0c\x00\x00\x08\xde\xad\xbe\xef',
+    'CWR': b'0909\xde\xad\xbe\xef\xde\xad\xbe\xef\r\x00\x00\x08\xde\xad\xbe\xef',
+    'SHUTDOWN_COMPLETE': b'\x0f\x1c\x0f\xe4\xbb{\x0f\x9cj\xd9\x9d\xc7\x0e\x00\x00\x04',
+}
 
 
 def test_sctp_pack():
-    sctp = SCTP(__s)
-    assert (__s == str(sctp))
-    sctp.sum = 0
-    assert (__s == str(sctp))
-
+    for k, v in test_bytearr.items():
+        sctp = SCTP(v)
+        assert (v == str(sctp))
+        sctp.sum = 0
+        print 'Successfully done packing %s' % k
 
 def test_sctp_unpack():
-    sctp = SCTP(__s)
-    assert (sctp.sport == 32836)
-    assert (sctp.dport == 80)
-    assert (len(sctp.chunks) == 1)
-    assert (len(sctp) == 72)
-    chunk = sctp.chunks[0]
-    assert (chunk.type == INIT)
-    assert (chunk.len == 60)
+    import binascii
+    for k, v in test_bytearr.items():
+        sctp = SCTP(v)
+        sctpchunk = sctp.chunks[0]
+        if isinstance(sctpchunk, ChunkData):
+            assert (sctp.sport == 4068)
+            assert (sctp.dport == 3868)
+            assert (sctpchunk.type == 0)
+            assert (sctpchunk.flags == 3)
+            assert (sctpchunk.len == 460)
+            assert (sctpchunk.tsn == 3145404316)
+            assert (sctpchunk.stream_id == 0)
+            assert (sctpchunk.stream_seq == 0)
+            assert (sctpchunk.proto_id == 0)
+            assert (binascii.hexlify(sctpchunk.data) == 'deadbeef')
+        elif isinstance(sctpchunk, ChunkInit):
+            assert (sctp.sport == 4068)
+            assert (sctp.dport == 3868)
+            assert (sctpchunk.type == 1)
+            assert (sctpchunk.flags == 0)
+            assert (sctpchunk.len == 20)
+            assert (sctpchunk.init_tag == 3145404316)
+            assert (sctpchunk.a_rwnd == 64000)
+            assert (sctpchunk.num_os == 10)
+            assert (sctpchunk.num_is == 10)
+            assert (sctpchunk.init_tsn == 3145404316)
+        elif isinstance(sctpchunk, ChunkInitAck):
+            assert (sctp.sport == 3868)
+            assert (sctp.dport == 4068)
+            assert (sctpchunk.type == 2)
+            assert (sctpchunk.flags == 0)
+            assert (sctpchunk.len == 452)
+            assert (sctpchunk.init_tag == 3461729935)
+            assert (sctpchunk.a_rwnd == 64000)
+            assert (sctpchunk.num_os == 10)
+            assert (sctpchunk.num_is == 10)
+            assert (sctpchunk.init_tsn == 3461729935)
+            assert (sctpchunk.cookie_param == 7)
+            assert (sctpchunk.param_len == 432)
+            assert (binascii.hexlify(sctpchunk.state_cookie) == (
+                'bb7b0f9c0000fa00000a0000bb7b0f9c000000000fe4000001000000040000000101010a0000000000'
+                '0000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+                '0000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+                '0000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+                '000000000000000000000000000000000000000000000000000000000000000000000000ce55ce8f00'
+                '00fa00000a0000ce55ce8f0f1c00000100000004000000010101140000000000000000000000000000'
+                '0000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+                '0000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+                '0000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+                '0000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+                '000000000000000000004f39d8584f3ac2b8'
+                )
+            )
+        elif isinstance(sctpchunk, ChunkSack):
+            assert (sctp.sport == 3868)
+            assert (sctp.dport == 4068)
+            assert (sctpchunk.type == 3)
+            assert (sctpchunk.flags == 0)
+            assert (sctpchunk.len == 16)
+            assert (sctpchunk.cum_tsn_ack == 3145404316)
+            assert (sctpchunk.a_rwnd == 64000)
+            assert (sctpchunk.num_gap_ack == 0)
+            assert (sctpchunk.num_dup_tsn == 0)
+        elif isinstance(sctpchunk, ChunkHeartbeat):
+            assert (sctp.sport == 2905)
+            assert (sctp.dport == 2905)
+            assert (sctpchunk.type == 4)
+            assert (sctpchunk.flags == 0)
+            assert (sctpchunk.len == 24)
+            assert (sctpchunk.hb_type == 1)
+            assert (sctpchunk.hb_len == 20)
+            assert (binascii.hexlify(sctpchunk.hb_info) == '40e44b920a1c062c1b66af7edead0000')
+        elif isinstance(sctpchunk, ChunkHeartbeatAck):
+            assert (sctp.sport == 2905)
+            assert (sctp.dport == 2905)
+            assert (sctpchunk.type == 5)
+            assert (sctpchunk.flags == 0)
+            assert (sctpchunk.len == 24)
+            assert (sctpchunk.hb_type == 1)
+            assert (sctpchunk.hb_len == 20)
+            assert (binascii.hexlify(sctpchunk.hb_info) == '40e44b920a1c062c1b66af7ebeef0000')
+        elif isinstance(sctpchunk, ChunkAbort):
+            assert (sctp.sport == 12345)
+            assert (sctp.dport == 12345)
+            assert (sctpchunk.type == 6)
+            assert (sctpchunk.flags == 0)
+            assert (sctpchunk.len == 4)
+        elif isinstance(sctpchunk, ChunkShutdown):
+            assert (sctp.sport == 3868)
+            assert (sctp.dport == 4068)
+            assert (sctpchunk.type == 7)
+            assert (sctpchunk.flags == 0)
+            assert (sctpchunk.len == 8)
+            assert (sctpchunk.cum_tsn_ack == 3145404317)
+        elif isinstance(sctpchunk, ChunkShutdownAck):
+            assert (sctp.sport == 4068)
+            assert (sctp.dport == 3868)
+            assert (sctpchunk.type == 8)
+            assert (sctpchunk.flags == 0)
+            assert (sctpchunk.len == 4)
+        elif isinstance(sctpchunk, ChunkError):
+            assert (sctp.sport == 12345)
+            assert (sctp.dport == 12345)
+            assert (sctpchunk.type == 9)
+            assert (sctpchunk.flags == 0)
+            assert (sctpchunk.len == 16)
+            assert (sctpchunk.cause_code == 1)
+            assert (sctpchunk.cause_len == 8)
+            assert ((struct.unpack('H', sctpchunk.invalid_id)[0] >> 8) == 153)
+        elif isinstance(sctpchunk, ChunkCookieEcho):
+            assert (sctp.sport == 4068)
+            assert (sctp.dport == 3868)
+            assert (sctpchunk.type == 10)
+            assert (sctpchunk.flags == 0)
+            assert (sctpchunk.len == 432)
+            assert (binascii.hexlify(sctpchunk.cookie) == (
+                'bb7b0f9c0000fa00000a0000bb7b0f9c000000000fe4000001000000040000000101010a0000000000'
+                '0000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+                '0000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+                '0000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+                '000000000000000000000000000000000000000000000000000000000000000000000000ce55ce8f00'
+                '00fa00000a0000ce55ce8f0f1c00000100000004000000010101140000000000000000000000000000'
+                '0000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+                '0000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+                '0000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+                '0000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+                '000000000000000000004f39d8584f3ac2b8'
+                )
+            )
+        elif isinstance(sctpchunk, ChunkCookieAck):
+            assert (sctp.sport == 3868)
+            assert (sctp.dport == 4068)
+            assert (sctpchunk.type == 11)
+            assert (sctpchunk.flags == 0)
+            assert (sctpchunk.len == 4)
+        elif isinstance(sctpchunk, ChunkECNE):
+            assert (sctp.sport == 12345)
+            assert (sctp.dport == 12345)
+            assert (sctpchunk.type == 12)
+            assert (sctpchunk.flags == 0)
+            assert (sctpchunk.len == 8)
+            assert (sctpchunk.lowest_tsn == 3735928559)
+        elif isinstance(sctpchunk, ChunkCWR):
+            assert (sctp.sport == 12345)
+            assert (sctp.dport == 12345)
+            assert (sctpchunk.type == 13)
+            assert (sctpchunk.flags == 0)
+            assert (sctpchunk.len == 8)
+            assert (sctpchunk.lowest_tsn == 3735928559)
+        elif isinstance(sctpchunk, ChunkShutdownComplete):
+            assert (sctp.sport == 3868)
+            assert (sctp.dport == 4068)
+            assert (sctpchunk.type == 14)
+            assert (sctpchunk.flags == 0)
+            assert (sctpchunk.len == 4)
+        print 'Successfully done unpacking %s' % k
 
 
 if __name__ == '__main__':
     test_sctp_pack()
     test_sctp_unpack()
     print 'Tests Successful...'
+


### PR DESCRIPTION
# Diameter enhancement: Support padding in AVPs

Hi,  
I implemented the padding support in diameter AVPs. Please review :-)

### Problem in current implementation

diameter.py fails parsing multiple AVPs due to the lack of consideration for padding.  
When an AVP has its data with padding, `AVP` class can only parse actual data part referring the AVP Length field, and it results in the failure of parsing the next AVP(AVP Code is parsed as zero...).

```
       0                   1                   2                   3
       0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
      |                           AVP Code                            |
      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
      |V M P r r r r r|                  AVP Length                   |
      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
      |                        Vendor-ID (opt)                        |
      +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
      |    Data ...       <= This sometimes has padding, which is not counted in Length.
      +-+-+-+-+-+-+-+-+
```

### What's done
Added padding feature when **packing Diameter header** and **unpacking Diameter AVP**.

#### Changes in Pack Diameter Header
1. Checks the each AVP(retrieved from `self.data`) Length if it is a multiple of four.
    * If so, `padlen` will be 0
    * If not, `padlen` is set to 1-3, depending on how much length is needed to fill.
2. Depending on `padlen`, creates null bytearray(varies from `b''` to `b'\x00\x00\x00'`) and append it to AVP.
3. Joins each AVPs as `self.data`.

**Example:**

Suppose Diameter class got AVP1 and AVP2, whose actual length is 9 and 18.

```
+-+-+-+-+-+-+-+-+-+
|  AVP1  (len=9)  |
+-+-+-+-+-+-+-+-+-+
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|           AVP2 (len=18)           |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
```

To adjust their length to multiple of four, add padding for each AVP.  

```
+-+-+-+-+-+-+-+-+-+-+-+-+
|  AVP1  (len=9)  | p1  |
+-+-+-+-+-+-+-+-+-+-+-+-+
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|           AVP2 (len=18)           |p2 |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
```

Now their length is 12 and 20. So let's merge them as a set of AVPs(=data of diameter header).

```
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|  AVP1  (len=9)  | p1  |           AVP2 (len=18)           |p2 |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
```

#### Changes in Unpack AVP
1. Checks the actual AVP Length(self.len) if it is a multiple of four.
    * If so, `padlen` will be 0
    * If not, `padlen` is set to 1-3, depending on how much length is needed to fill.
2. Adds the `padlen` to the length of `data`. 

**Example:**

An AVP has its length in Length field. If that length is not multiple of four, it means it hes the padding to fill.  
When comparing the length value the actual length. The gap between them is the length of padding.

```
/ value in length \ 
/actual length of bytes \
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|  AVP1  (len=9)  |     |           AVP2 (len=18)           |p2 |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
```

So let's unpack with actual length by adding the length of padding to the target range of unpacking, not to parse padding bytes as next AVP.

```
/range to unpack as AVP1\
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|  AVP1  (len=9)  |     |           AVP2 (len=18)           |p2 |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
```

If not doing this, AVP2 cannot be parsed correctly.

```
                  /      wrong range to unpack as AVP2         \
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
|  AVP1  (len=9)  |     |           AVP2 (len=18)           |p2 |
+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
                   ^^^^^
                   AVP Code would be zero, parsing results in failure.
```

### Other modifications

These don't affect the creating/parsing logic, but I added some lines of code for enhancement.

* Wrote Class information docstrings.
* Let the command codes inside the `Diameter` class, as they won't be referred from other classes.
* Added `avp_codes` in `AVP` class(Only supports the ones defined in rfc6733)
* Modified test method to make it simple. Bytearray for testing is no longer needed.


### Further enhancements

This is not included in this commit but I'm planning to enhance this further. Let me create a new issue in the future to discuss how we should implement them if needed.

1. Implement child classes for basic AVPs(where app_id in header is 0) to create/parse it in more easy way.
2. Implement some application-specific AVPs like Gx/Gy in other class(or even other file maybe).
