### PR TITLE
Do circular imports in icmp and icmp6 modules correctly (Issue #324)

### DIFF
--- a/dpkt/icmp.py
+++ b/dpkt/icmp.py
@@ -5,7 +5,6 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 from . import dpkt
-from . import ip
 
 # Types (icmp_type) and codes (icmp_code) -
 # http://www.iana.org/assignments/icmp-parameters
@@ -98,6 +97,7 @@ class ICMP(dpkt.Packet):
 
         def unpack(self, buf):
             dpkt.Packet.unpack(self, buf)
+            from . import ip
             self.data = self.ip = ip.IP(self.data)
 
     class Unreach(Quote):

--- a/dpkt/icmp6.py
+++ b/dpkt/icmp6.py
@@ -4,7 +4,6 @@
 from __future__ import absolute_import
 
 from . import dpkt
-from . import ip6
 
 ICMP6_DST_UNREACH = 1  # dest unreachable, codes:
 ICMP6_PACKET_TOO_BIG = 2  # packet too big
@@ -61,6 +60,7 @@ class ICMP6(dpkt.Packet):
 
         def unpack(self, buf):
             dpkt.Packet.unpack(self, buf)
+            from . import ip6
             self.data = self.ip6 = ip6.IP6(self.data)
 
     class Unreach(Error): pass


### PR DESCRIPTION
There are circular deps between ip.py and icmp.py/icmp6.py modules.
Because of alphabetical imports in __init__.py, the icmp modules
are imported before ip.py, but they both need ip.py and ip.py during
initialization tries to import these icmp.

Because of these circular imports, icmp and icmp6 data in IP packets
weren't parsed correctly (#324). This patch does the imports in
slightly better fashion, so parsing of ICMP packets in IP works
again.