### PR TITLE
Do not parse L4 headers for fragmented IP packets with fragment offset > 0

### DIFF
--- a/dpkt/ip.py
+++ b/dpkt/ip.py
@@ -140,7 +140,7 @@ class IP(dpkt.Packet):
         else:  # very likely due to TCP segmentation offload
             buf = buf[self.__hdr_len__ + ol:]
         try:
-            self.data = self._protosw[self.p](buf)
+            self.data = self._protosw[self.p](buf) if self.offset == 0 else buf
             setattr(self, self.data.__class__.__name__.lower(), self.data)
         except (KeyError, dpkt.UnpackError):
             self.data = buf


### PR DESCRIPTION
Fixed #102 issue