### PR TITLE
removing all the deprecated methods

### DIFF
--- a/dpkt/aoe.py
+++ b/dpkt/aoe.py
@@ -18,7 +18,7 @@ class AOE(dpkt.Packet):
         __hdr__: Header fields of AOE.
         data: Message data.
     """
-    
+
     __hdr__ = (
         ('ver_fl', 'B', 0x10),
         ('err', 'B', 0),
@@ -62,22 +62,6 @@ class AOE(dpkt.Packet):
             return dpkt.Packet.pack_hdr(self)
         except struct.error as e:
             raise dpkt.PackError(str(e))
-
-    # Deprecated methods, will be removed in the future
-    # =================================================
-    @deprecated('ver')
-    def _get_ver(self): return self.ver
-
-    @deprecated('ver')
-    def _set_ver(self, ver): self.ver = ver
-
-    @deprecated('fl')
-    def _get_fl(self): return self.fl
-
-    @deprecated('fl')
-    def _set_fl(self, fl): self.fl = fl
-    # =================================================
-
 
 
 AOE_CMD_ATA = 0

--- a/dpkt/bgp.py
+++ b/dpkt/bgp.py
@@ -305,41 +305,6 @@ class BGP(dpkt.Packet):
             def extended_length(self, e):
                 self.flags = (self.flags & ~0x10) | ((e & 0x1) << 4)
 
-            # Deprecated methods, will be removed in the future
-            # ======================================================
-            @deprecated('optional')
-            def _get_o(self):
-                return self.optional
-
-            @deprecated('optional')
-            def _set_o(self, o):
-                self.optional = o
-
-            @deprecated('transitive')
-            def _get_t(self):
-                return self.transitive
-
-            @deprecated('transitive')
-            def _set_t(self, t):
-                self.transitive = t
-
-            @deprecated('partial')
-            def _get_p(self):
-                return self.partial
-
-            @deprecated('partial')
-            def _set_p(self, p):
-                self.partial = p
-
-            @deprecated('extended_length')
-            def _get_e(self):
-                return self.extended_length
-
-            @deprecated('extended_length')
-            def _set_e(self, e):
-                self.extended_length = e
-            # ======================================================
-
             def unpack(self, buf):
                 dpkt.Packet.unpack(self, buf)
 

--- a/dpkt/diameter.py
+++ b/dpkt/diameter.py
@@ -75,33 +75,6 @@ class Diameter(dpkt.Packet):
     def retransmit_flag(self, t):
         self.flags = (self.flags & ~0x10) | ((t & 0x1) << 4)
 
-    # Deprecated methods, will be removed in the future
-    # ======================================================
-    @deprecated('request_flag')
-    def _get_r(self): return self.request_flag
-
-    @deprecated('request_flag')
-    def _set_r(self, r): self.request_flag = r
-
-    @deprecated('proxiable_flag')
-    def _get_p(self): return self.proxiable_flag
-
-    @deprecated('proxiable_flag')
-    def _set_p(self, p): self.proxiable_flag = p
-
-    @deprecated('error_flag')
-    def _get_e(self): return self.error_flag
-
-    @deprecated('error_flag')
-    def _set_e(self, e): self.error_flag = e
-
-    @deprecated('request_flag')
-    def _get_t(self): return self.request_flag
-
-    @deprecated('request_flag')
-    def _set_t(self, t): self.request_flag = t
-    # ======================================================
-
     def unpack(self, buf):
         dpkt.Packet.unpack(self, buf)
         self.cmd = (compat_ord(self.cmd[0]) << 16) | \
@@ -160,33 +133,6 @@ class AVP(dpkt.Packet):
     @protected_flag.setter
     def protected_flag(self, p):
         self.flags = (self.flags & ~0x20) | ((p & 0x1) << 5)
-
-    # Deprecated methods, will be removed in the future
-    # ======================================================
-    @deprecated('vendor_flag')
-    def _get_v(self):
-        return self.vendor_flag
-
-    @deprecated('vendor_flag')
-    def _set_v(self, v):
-        self.vendor_flag = v
-
-    @deprecated('mandatory_flag')
-    def _get_m(self):
-        return self.mandatory_flag
-
-    @deprecated('mandatory_flag')
-    def _set_m(self, m):
-        self.mandatory_flag = m
-
-    @deprecated('protected_flag')
-    def _get_p(self):
-        return self.protected_flag
-
-    @deprecated('protected_flag')
-    def _set_p(self, p):
-        self.protected_flag = p
-    # ======================================================
 
     def unpack(self, buf):
         dpkt.Packet.unpack(self, buf)

--- a/dpkt/dns.py
+++ b/dpkt/dns.py
@@ -225,65 +225,6 @@ class DNS(dpkt.Packet):
     def rcode(self, v):
         self.op = (self.op & ~0xf) | (v & 0xf)
 
-    # Deprecated methods, will be removed in the future
-    # ======================================================
-    @deprecated('qr')
-    def get_qr(self):
-        return self.qr
-
-    @deprecated('qr')
-    def set_qr(self, v):
-        self.qr = v
-
-    @deprecated('opcode')
-    def get_opcode(self):
-        return self.opcode
-
-    @deprecated('opcode')
-    def set_opcode(self, v):
-        self.opcode = v
-
-    @deprecated('aa')
-    def get_aa(self):
-        return self.aa
-
-    @deprecated('aa')
-    def set_aa(self, v):
-        self.aa = v
-
-    @deprecated('rd')
-    def get_rd(self):
-        return self.rd
-
-    @deprecated('rd')
-    def set_rd(self, v):
-        self.rd = v
-
-    @deprecated('ra')
-    def get_ra(self):
-        return self.ra
-
-    @deprecated('ra')
-    def set_ra(self, v):
-        self.ra = v
-
-    @deprecated('zero')
-    def get_zero(self):
-        return self.zero
-
-    @deprecated('zero')
-    def set_zero(self, v):
-        self.zero = v
-
-    @deprecated('rcode')
-    def get_rcode(self):
-        return self.rcode
-
-    @deprecated('rcode')
-    def set_rcode(self, v):
-        self.rcode = v
-    # ======================================================
-
     class Q(dpkt.Packet):
         """DNS question."""
         __hdr__ = (
@@ -488,29 +429,6 @@ def test_pack_name():
     # Empty name is \0
     x = pack_name('', 0, {})
     assert x == b'\0'
-
-
-def test_deprecated_methods():
-    """Test deprecated methods. Note: when they are removed so should this test"""
-    s = b'g\x02\x81\x80\x00\x01\x00\x01\x00\x03\x00\x00\x011\x011\x03211\x03141\x07in-addr\x04arpa\x00\x00\x0c\x00\x01\xc0\x0c\x00\x0c\x00\x01\x00\x00\r6\x00$\x07default\nv-umce-ifs\x05umnet\x05umich\x03edu\x00\xc0\x0e\x00\x02\x00\x01\x00\x00\r6\x00\r\x06shabby\x03ifs\xc0O\xc0\x0e\x00\x02\x00\x01\x00\x00\r6\x00\x0f\x0cfish-license\xc0m\xc0\x0e\x00\x02\x00\x01\x00\x00\r6\x00\x0b\x04dns2\x03itd\xc0O'
-    my_dns = DNS(s)
-    my_dns.get_aa()
-    my_dns.get_opcode()
-    qr = my_dns.get_qr()
-    my_dns.set_qr(qr)
-    qr2 = my_dns.get_qr()
-    assert qr == qr2
-
-
-def test_deprecated_method_performance():
-    """Test the performance hit for the deprecation decorator"""
-    from timeit import Timer
-
-    s = b'g\x02\x81\x80\x00\x01\x00\x01\x00\x03\x00\x00\x011\x011\x03211\x03141\x07in-addr\x04arpa\x00\x00\x0c\x00\x01\xc0\x0c\x00\x0c\x00\x01\x00\x00\r6\x00$\x07default\nv-umce-ifs\x05umnet\x05umich\x03edu\x00\xc0\x0e\x00\x02\x00\x01\x00\x00\r6\x00\r\x06shabby\x03ifs\xc0O\xc0\x0e\x00\x02\x00\x01\x00\x00\r6\x00\x0f\x0cfish-license\xc0m\xc0\x0e\x00\x02\x00\x01\x00\x00\r6\x00\x0b\x04dns2\x03itd\xc0O'
-    my_dns = DNS(s)
-    t1 = Timer(lambda: my_dns.aa).timeit(10000)
-    t2 = Timer(my_dns.get_aa).timeit(10000)
-    print('Performance of dns.aa vs. dns.get_aa(): %f %f' % (t1, t2))
 
 
 def test_random_data():

--- a/dpkt/gre.py
+++ b/dpkt/gre.py
@@ -56,21 +56,6 @@ class GRE(dpkt.Packet):
     def recur(self, v):
         self.flags = (self.flags & ~0xe0) | ((v & 0x7) << 5)
 
-    # Deprecated methods, will be removed in the future
-    # =================================================
-    @deprecated('v')
-    def get_v(self): return self.v
-
-    @deprecated('v')
-    def set_v(self, v): self.v = v
-
-    @deprecated('recur')
-    def get_recur(self): return self.recur
-
-    @deprecated('recur')
-    def set_recur(self, v): self.recur = v
-    # =================================================
-
     class SRE(dpkt.Packet):
         __hdr__ = [
             ('family', 'H', 0),

--- a/dpkt/ieee80211.py
+++ b/dpkt/ieee80211.py
@@ -220,75 +220,6 @@ class IEEE80211(dpkt.Packet):
     def order(self, val):
         self.framectl = (val << _ORDER_SHIFT) | (self.framectl & ~_ORDER_MASK)
 
-    # Deprecated methods, will be removed in the future
-    # =================================================
-    @deprecated('version')
-    def _get_version(self): return self.version
-
-    @deprecated('version')
-    def _set_version(self, val): self.version = val
-
-    @deprecated('type')
-    def _get_type(self): return self.type
-
-    @deprecated('type')
-    def _set_type(self, val): self.type = val
-
-    @deprecated('subtype')
-    def _get_subtype(self): return self.subtype
-
-    @deprecated('subtype')
-    def _set_subtype(self, val): self.subtype = val
-
-    @deprecated('to_ds')
-    def _get_to_ds(self): return self.to_ds
-
-    @deprecated('to_ds')
-    def _set_to_ds(self, val): self.to_ds = val
-
-    @deprecated('from_ds')
-    def _get_from_ds(self): return self.from_ds
-
-    @deprecated('from_ds')
-    def _set_from_ds(self, val): self.from_ds = val
-
-    @deprecated('more_frag')
-    def _get_more_frag(self): return self.more_frag
-
-    @deprecated('more_frag')
-    def _set_more_frag(self, val): self.more_frag = val
-
-    @deprecated('retry')
-    def _get_retry(self): return self.retry
-
-    @deprecated('retry')
-    def _set_retry(self, val): self.retry = val
-
-    @deprecated('pwr_mgt')
-    def _get_pwr_mgt(self): return self.pwr_mgt
-
-    @deprecated('pwr_mgt')
-    def _set_pwr_mgt(self, val): self.pwr_mgt = val
-
-    @deprecated('more_data')
-    def _get_more_data(self): return self.more_data
-
-    @deprecated('more_data')
-    def _set_more_data(self, val): self.more_data = val
-
-    @deprecated('wep')
-    def _get_wep(self): return self.wep
-
-    @deprecated('wep')
-    def _set_wep(self, val): self.wep = val
-
-    @deprecated('order')
-    def _get_order(self): return self.order
-
-    @deprecated('order')
-    def _set_order(self, val): self.order = val
-    # =================================================
-
     def unpack_ies(self, buf):
         self.ies = []
 
@@ -487,33 +418,6 @@ class IEEE80211(dpkt.Packet):
         @tid.setter
         def tid(self, val):
             self.ctl = (val << _TID_SHIFT) | (self.ctl & ~_TID_MASK)
-
-        # Deprecated methods, will be removed in the future
-        # =================================================
-        @deprecated('compressed')
-        def _get_compressed(self): return self.compressed
-
-        @deprecated('compressed')
-        def _set_compressed(self, val): self.compressed = val
-
-        @deprecated('ack_policy')
-        def _get_ack_policy(self): return self.ack_policy
-
-        @deprecated('ack_policy')
-        def _set_ack_policy(self, val): self.ack_policy = val
-
-        @deprecated('multi_tid')
-        def _get_multi_tid(self): return self.multi_tid
-
-        @deprecated('multi_tid')
-        def _set_multi_tid(self, val): self.multi_tid = val
-
-        @deprecated('tid')
-        def _get_tid(self): return self.tid
-
-        @deprecated('tid')
-        def _set_tid(self, val): self.tid = val
-        # =================================================
 
         def unpack(self, buf):
             dpkt.Packet.unpack(self, buf)

--- a/dpkt/ip.py
+++ b/dpkt/ip.py
@@ -89,25 +89,6 @@ class IP(dpkt.Packet):
     def offset(self, offset):
         self.off = (self.off & ~IP_OFFMASK) | (offset >> 3)
 
-    # Deprecated methods, will be removed in the future
-    # =================================================
-    @deprecated('v')
-    def _get_v(self):
-        return self.v
-
-    @deprecated('v')
-    def _set_v(self, v):
-        self.v = v
-
-    @deprecated('hl')
-    def _get_hl(self):
-        return self.hl
-
-    @deprecated('hl')
-    def _set_hl(self, hl):
-        self.hl = hl
-    # =================================================
-
     def __len__(self):
         return self.__hdr_len__ + len(self.opts) + len(self.data)
 

--- a/dpkt/ip6.py
+++ b/dpkt/ip6.py
@@ -55,33 +55,6 @@ class IP6(dpkt.Packet):
     def flow(self, v):
         self._v_fc_flow = (self._v_fc_flow & ~0xfffff) | (v & 0xfffff)
 
-    # Deprecated methods, will be removed in the future
-    # =================================================
-    @deprecated('v')
-    def _get_v(self):
-        return self.v
-
-    @deprecated('v')
-    def _set_v(self, v):
-        self.v = v
-
-    @deprecated('fc')
-    def _get_fc(self):
-        return self.fc
-
-    @deprecated('fc')
-    def _set_fc(self, v):
-        self.fc = v
-
-    @deprecated('flow')
-    def _get_flow(self):
-        return self.flow
-
-    @deprecated('flow')
-    def _set_flow(self, v):
-        self.flow = v
-    # =================================================
-
     def unpack(self, buf):
         dpkt.Packet.unpack(self, buf)
         self.extension_hdrs = {}
@@ -211,15 +184,6 @@ class IP6RoutingHeader(IP6ExtensionHeader):
     def sl_bits(self, v):
         self.rsvd_sl_bits = (self.rsvd_sl_bits & ~0xfffff) | (v & 0xfffff)
 
-    # Deprecated methods, will be removed in the future
-    # =================================================
-    @deprecated('sl_bits')
-    def _get_sl_bits(self): return self.sl_bits
-
-    @deprecated('sl_bits')
-    def _set_sl_bits(self, v): self.sl_bits = v
-    # =================================================
-
     def unpack(self, buf):
         hdr_size = 8
         addr_size = 16
@@ -266,21 +230,6 @@ class IP6FragmentHeader(IP6ExtensionHeader):
     @m_flag.setter
     def m_flag(self, v):
         self.frag_off_resv_m = (self.frag_off_resv_m & ~0xfffe) | v
-
-    # Deprecated methods, will be removed in the future
-    # =================================================
-    @deprecated('frag_off')
-    def _get_frag_off(self): return self.frag_off
-
-    @deprecated('frag_off')
-    def _set_frag_off(self, v): self.frag_off = v
-
-    @deprecated('m_flag')
-    def _get_m_flag(self): return self.m_flag
-
-    @deprecated('m_flag')
-    def _set_m_flag(self, v): self.m_flag = v
-    # =================================================
 
 
 class IP6AHHeader(IP6ExtensionHeader):

--- a/dpkt/ntp.py
+++ b/dpkt/ntp.py
@@ -34,7 +34,7 @@ class NTP(dpkt.Packet):
         __hdr__: Header fields of NTP.
         TODO.
     """
-    
+
     __hdr__ = (
         ('flags', 'B', 0),
         ('stratum', 'B', 0),
@@ -73,26 +73,6 @@ class NTP(dpkt.Packet):
     def mode(self, mode):
         self.flags = (self.flags & ~0x7) | (mode & 0x7)
 
-    # Deprecated methods, will be removed in the future
-    # =================================================
-    @deprecated('v')
-    def _get_v(self): return self.v
-
-    @deprecated('v')
-    def _set_v(self, v): self.v = v
-
-    @deprecated('li')
-    def _get_li(self): return self.li
-
-    @deprecated('li')
-    def _set_li(self, li): self.li = li
-
-    @deprecated('mode')
-    def _get_mode(self): return self.mode
-
-    @deprecated('mode')
-    def _set_mode(self, mode): self.mode = mode
-    # =================================================
 
 __s = b'\x24\x02\x04\xef\x00\x00\x00\x84\x00\x00\x33\x27\xc1\x02\x04\x02\xc8\x90\xec\x11\x22\xae\x07\xe5\xc8\x90\xf9\xd9\xc0\x7e\x8c\xcd\xc8\x90\xf9\xd9\xda\xc5\xb0\x78\xc8\x90\xf9\xd9\xda\xc6\x8a\x93'
 

--- a/dpkt/pim.py
+++ b/dpkt/pim.py
@@ -39,21 +39,6 @@ class PIM(dpkt.Packet):
     def type(self, type):
         self._v_type = (self._v_type & 0xf0) | type
 
-    # Deprecated methods, will be removed in the future
-    # =================================================
-    @deprecated('v')
-    def _get_v(self): return self.v
-
-    @deprecated('v')
-    def _set_v(self, v): self.v = v
-
-    @deprecated('type')
-    def _get_type(self): return self.type
-
-    @deprecated('type')
-    def _set_type(self, type): self.type = type
-    # =================================================
-
     def __bytes__(self):
         if not self.sum:
             self.sum = dpkt.in_cksum(dpkt.Packet.__bytes__(self))

--- a/dpkt/pppoe.py
+++ b/dpkt/pppoe.py
@@ -28,7 +28,7 @@ class PPPoE(dpkt.Packet):
         __hdr__: Header fields of PPPoE.
         TODO.
     """
-    
+
     __hdr__ = (
         ('_v_type', 'B', 0x11),
         ('code', 'B', 0),
@@ -51,21 +51,6 @@ class PPPoE(dpkt.Packet):
     @type.setter
     def type(self, t):
         self._v_type = (self._v_type & 0xf0) | t
-
-    # Deprecated methods, will be removed in the future
-    # =================================================
-    @deprecated('v')
-    def _get_v(self): return self.v
-
-    @deprecated('v')
-    def _set_v(self, v): self.v = v
-
-    @deprecated('type')
-    def _get_type(self): return self.type
-
-    @deprecated('type')
-    def _set_type(self, t): self.type = t
-    # =================================================
 
     def unpack(self, buf):
         dpkt.Packet.unpack(self, buf)

--- a/dpkt/radiotap.py
+++ b/dpkt/radiotap.py
@@ -89,7 +89,7 @@ class Radiotap(dpkt.Packet):
         __hdr__: Header fields of Radiotap.
         TODO.
     """
-    
+
     __hdr__ = (
         ('version', 'B', 0),
         ('pad', 'B', 0),
@@ -233,145 +233,6 @@ class Radiotap(dpkt.Packet):
     def ext_present(self, val):
         self.present_flags |= val << _EXT_SHIFT
 
-    # Deprecated methods, will be removed in the future
-    # =================================================
-    @deprecated('tsft_present')
-    def _get_tsft_present(self):
-        return self.tsft_present
-
-    @deprecated('tsft_present')
-    def _set_tsft_present(self, val):
-        self.tsft_present = val
-
-    @deprecated('flags_present')
-    def _get_flags_present(self):
-        return self.flags_present
-
-    @deprecated('flags_present')
-    def _set_flags_present(self, val):
-        self.flags_present = val
-
-    @deprecated('rate_present')
-    def _get_rate_present(self):
-        return self.rate_present
-
-    @deprecated('rate_present')
-    def _set_rate_present(self, val):
-        self.rate_present = val
-
-    @deprecated('channel_present')
-    def _get_channel_present(self):
-        return self.channel_present
-
-    @deprecated('channel_present')
-    def _set_channel_present(self, val):
-        self.channel_present = val
-
-    @deprecated('fhss_present')
-    def _get_fhss_present(self):
-        return self.fhss_present
-
-    @deprecated('fhss_present')
-    def _set_fhss_present(self, val):
-        self.fhss_present = val
-
-    @deprecated('ant_sig_present')
-    def _get_ant_sig_present(self):
-        return self.ant_sig_present
-
-    @deprecated('ant_sig_present')
-    def _set_ant_sig_present(self, val):
-        self.ant_sig_present = val
-
-    @deprecated('ant_noise_present')
-    def _get_ant_noise_present(self):
-        return self.ant_noise_present
-
-    @deprecated('ant_noise_present')
-    def _set_ant_noise_present(self, val):
-        self.ant_noise_present = val
-
-    @deprecated('lock_qual_present')
-    def _get_lock_qual_present(self):
-        return self.lock_qual_present
-
-    @deprecated('lock_qual_present')
-    def _set_lock_qual_present(self, val):
-        self.lock_qual_present = val
-
-    @deprecated('tx_attn_present')
-    def _get_tx_attn_present(self):
-        return self.tx_attn_present
-
-    @deprecated('tx_attn_present')
-    def _set_tx_attn_present(self, val):
-        self.tx_attn_present = val
-
-    @deprecated('db_tx_attn_present')
-    def _get_db_tx_attn_present(self):
-        return self.db_tx_attn_present
-
-    @deprecated('db_tx_attn_present')
-    def _set_db_tx_attn_present(self, val):
-        self.db_tx_attn_present = val
-
-    @deprecated('dbm_tx_power_present')
-    def _get_dbm_power_present(self):
-        return self.dbm_tx_power_present
-
-    @deprecated('dbm_tx_power_present')
-    def _set_dbm_power_present(self, val):
-        self.dbm_tx_power_present = val
-
-    @deprecated('ant_present')
-    def _get_ant_present(self):
-        return self.ant_present
-
-    @deprecated('ant_present')
-    def _set_ant_present(self, val):
-        self.ant_present = val
-
-    @deprecated('db_ant_sig_present')
-    def _get_db_ant_sig_present(self):
-        return self.db_ant_sig_present
-
-    @deprecated('db_ant_sig_present')
-    def _set_db_ant_sig_present(self, val):
-        self.db_ant_sig_present = val
-
-    @deprecated('db_ant_noise_present')
-    def _get_db_ant_noise_present(self):
-        return self.db_ant_noise_present
-
-    @deprecated('db_ant_noise_present')
-    def _set_db_ant_noise_present(self, val):
-        self.db_ant_noise_present = val
-
-    @deprecated('rx_flags_present')
-    def _get_rx_flags_present(self):
-        return self.rx_flags_present
-
-    @deprecated('rx_flags_present')
-    def _set_rx_flags_present(self, val):
-        self.rx_flags_present = val
-
-    @deprecated('chanplus_present')
-    def _get_chanplus_present(self):
-        return self.chanplus_present
-
-    @deprecated('chanplus_present')
-    def _set_chanplus_present(self, val):
-        self.chanplus_present = val
-
-    @deprecated('ext_present')
-    def _get_ext_present(self):
-        return self.ext_present
-
-    @deprecated('ext_present')
-    def _set_ext_present(self, val):
-        self.ext_present = val
-    # =================================================
-
     def unpack(self, buf):
         dpkt.Packet.unpack(self, buf)
         self.data = buf[socket.ntohs(self.length):]
@@ -450,14 +311,6 @@ class Radiotap(dpkt.Packet):
         @fcs.setter
         def fcs(self, v): (v << _FCS_SHIFT) | (self.val & ~_FCS_MASK)
 
-        # Deprecated methods, will be removed in the future
-        # =================================================
-        @deprecated('fcs')
-        def _get_fcs_present(self): return self.fcs
-
-        @deprecated('fcs')
-        def _set_fcs_present(self, v): self.fcs = v
-        # =================================================
 
     class LockQuality(dpkt.Packet):
         __hdr__ = (

--- a/dpkt/rtp.py
+++ b/dpkt/rtp.py
@@ -85,45 +85,6 @@ class RTP(Packet):
     @pt.setter
     def pt(self, m): self._type = (m << _PT_SHIFT) | (self._type & ~_PT_MASK)
 
-    # Deprecated methods, will be removed in the future
-    # =================================================
-    @deprecated('version')
-    def _get_version(self): return self.version
-
-    @deprecated('version')
-    def _set_version(self, ver): self.version = ver
-
-    @deprecated('p')
-    def _get_p(self): return self.p
-
-    @deprecated('p')
-    def _set_p(self, p): self.p = p
-
-    @deprecated('x')
-    def _get_x(self): return self.x
-
-    @deprecated('x')
-    def _set_x(self, x): self.x = x
-
-    @deprecated('cc')
-    def _get_cc(self): return self.cc
-
-    @deprecated('cc')
-    def _set_cc(self, cc): self.cc = cc
-
-    @deprecated('m')
-    def _get_m(self): return self.m
-
-    @deprecated('m')
-    def _set_m(self, m): self.m = m
-
-    @deprecated('pt')
-    def _get_pt(self): return self.pt
-
-    @deprecated('pt')
-    def _set_pt(self, pt): self.pt = pt
-    # =================================================
-
     def __len__(self):
         return self.__hdr_len__ + len(self.csrc) + len(self.data)
 

--- a/dpkt/tcp.py
+++ b/dpkt/tcp.py
@@ -53,15 +53,6 @@ class TCP(dpkt.Packet):
     def off(self, off):
         self._off = (off << 4) | (self._off & 0xf)
 
-    # Deprecated methods, will be removed in the future
-    # =================================================
-    @deprecated('off')
-    def _get_off(self): return self.off
-
-    @deprecated('off')
-    def _set_off(self, off): self.off = off
-    # =================================================
-
     def __len__(self):
         return self.__hdr_len__ + len(self.opts) + len(self.data)
 

--- a/dpkt/vrrp.py
+++ b/dpkt/vrrp.py
@@ -46,21 +46,6 @@ class VRRP(dpkt.Packet):
     def type(self, v):
         self._v_type = (self._v_type & 0xf0) | (v & 0x0f)
 
-    # Deprecated methods, will be removed in the future
-    # =================================================
-    @deprecated('v')
-    def _get_v(self): return self.v
-
-    @deprecated('v')
-    def _set_v(self, v): self.v = v
-
-    @deprecated('type')
-    def _get_type(self): return self.type
-
-    @deprecated('type')
-    def _set_type(self, v): self.type = v
-    # =================================================
-
     def unpack(self, buf):
         dpkt.Packet.unpack(self, buf)
         l = []


### PR DESCRIPTION
Removing all the deprecated methods. Note: these methods have been decorated with a warning message for almost 2 years now, so the removal of these methods should take no one by surprise. If you need to use any of these deprecated methods you can use the use the dpkt==1.8.8 version (https://github.com/kbandla/dpkt/releases/tag/v1.8.8)