### PR TITLE
On windows, check if the file is opened in binary mode

### DIFF
--- a/dpkt/pcap.py
+++ b/dpkt/pcap.py
@@ -197,6 +197,8 @@ class Writer(object):
     """
 
     def __init__(self, fileobj, snaplen=1500, linktype=DLT_EN10MB, nano=False):
+        if fileobj.mode != 'wb':
+            raise ValueError('PCAP file not in binary mode (rb)')
         self.__f = fileobj
         self._precision = 9 if nano else 6
         magic = TCPDUMP_MAGIC_NANO if nano else TCPDUMP_MAGIC
@@ -240,6 +242,9 @@ class Reader(object):
 
     def __init__(self, fileobj):
         self.name = getattr(fileobj, 'name', '<%s>' % fileobj.__class__.__name__)
+        if sys.platform.startswith('win'):
+            if fileobj.mode != 'rb':
+                raise ValueError('PCAP file (%s) not opened in binary mode (rb)'%self.name)
         self.__f = fileobj
         buf = self.__f.read(FileHdr.__hdr_len__)
         self.__fh = FileHdr(buf)


### PR DESCRIPTION
Most window users open the files with the wrong mode. Unfortunately, the file mode property is read-only, so we can not fix it on the fly. Raise an exception instead. 