### PR TITLE
Replace bytes() with str.encode()

### DIFF
--- a/dpkt/dpkt.py
+++ b/dpkt/dpkt.py
@@ -141,7 +141,7 @@ class Packet(_MetaPacket("Temp", (object,), {})):
         return str(self.__bytes__())
     
     def __bytes__(self):
-        return self.pack_hdr() + bytes(self.data)
+        return self.pack_hdr() + bytes(self.data, 'utf-8')
 
     def pack_hdr(self):
         """Return packed header string."""

--- a/dpkt/dpkt.py
+++ b/dpkt/dpkt.py
@@ -141,7 +141,7 @@ class Packet(_MetaPacket("Temp", (object,), {})):
         return str(self.__bytes__())
     
     def __bytes__(self):
-        return self.pack_hdr() + bytes(self.data, 'utf-8')
+        return self.pack_hdr() + self.data.encode('utf-8')
 
     def pack_hdr(self):
         """Return packed header string."""


### PR DESCRIPTION
Python 3 requires the encoding to be specified when using bytes() while Python 2 does not support the option. 

**bytes(self.data)** works in Python 2 but throws a TypeError in Python 3
**bytes(self.data, utf-8)** works in Python 3 but throws a TypeError in Python 2

**str.encode()** works in both Python 2 and 3. See https://www.python.org/dev/peps/pep-0358/