### PR TITLE
igmp.py: Read group as 4-byte dotted quad, not 4-byte int

### DIFF
--- a/dpkt/igmp.py
+++ b/dpkt/igmp.py
@@ -20,7 +20,7 @@ class IGMP(dpkt.Packet):
         ('type', 'B', 0),
         ('maxresp', 'B', 0),
         ('sum', 'H', 0),
-        ('group', 'I', 0)
+        ('group', '4s', '\x00' * 4)
     )
 
     def __bytes__(self):


### PR DESCRIPTION
Read the group IPv4 address like we do in other places in dpkt as a 4-byte string. 