### PR TITLE
Speed up packet writing for pcap. Add writepkts method.

### DIFF
--- a/dpkt/dpkt.py
+++ b/dpkt/dpkt.py
@@ -8,6 +8,7 @@ import itertools
 import socket
 import struct
 import array
+from functools import partial
 
 from .compat import compat_ord, compat_izip, iteritems
 
@@ -95,8 +96,12 @@ class Packet(_MetaPacket("Temp", (object,), {})):
         else:
             for k in self.__hdr_fields__:
                 setattr(self, k, copy.copy(self.__hdr_defaults__[k]))
+
             for k, v in iteritems(kwargs):
                 setattr(self, k, v)
+
+        if hasattr(self, '__hdr_fmt__'):
+          self._pack_hdr = partial(struct.pack, self.__hdr_fmt__)
 
     def __len__(self):
         return self.__hdr_len__ + len(self.data)
@@ -146,8 +151,9 @@ class Packet(_MetaPacket("Temp", (object,), {})):
     def pack_hdr(self):
         """Return packed header string."""
         try:
-            return struct.pack(self.__hdr_fmt__,
-                               *[getattr(self, k) for k in self.__hdr_fields__])
+            return self._pack_hdr(
+              *[getattr(self, k) for k in self.__hdr_fields__]
+            )
         except struct.error:
             vals = []
             for k in self.__hdr_fields__:


### PR DESCRIPTION
Speed up the packet output process and add additional methods to improve performance under certain conditions to address #391 

This works by moving endianness testing to Writer initialization and creating a partial function called `_pack_hdr` on the `Packet` class which allows much faster access to the struct packing method with an already constructed `__hdr_fmt__`. 

The original writepkt method is available, with the same signature, but improved performance. In addition two new methods are added.

writepkt_time(self, pkt, ts)
--------------------------------
By taking a non-optional timestamp, we can skip the test for timestamp and gain a marginal speed improvement. As this is a new method, the bytes() call in writepkt is omitted, gaining another marginal speed improvement.

writepkts(self, pkts)
-------------------------
pkts must be an iterable of tuples (ts, pkt). Although this is the other way round from writepkt, and therefore possibly confusing, it is the same order as readpkts. This means that the mass input and output functions are of the same format.

testing
======

The motivation for this work is speed. Writing 1 million packets with timestamps gives an average of 80% time reduction (500% speed increase).

Test was performed using a generator to produce the same packet, and `time.perf_counter()` to give the time measurements.

Method at [this gist](https://gist.github.com/crocogorical/986ca4e2fe82dc834fbdad498ce6ecf4), with `80c8545f6537ecd56b3ce50c8a6984291a73b666` imported as `dpkt_master` for comparison.

```
TIMES 5, PACKETS 1000000
perf   perf%   stdev  doc
28.629   0.00%  1.008 original writepkt(pkt, ts)
28.265  -1.27%  0.187 original writepkt(pkt)
 8.594 -69.98%  0.026 writepkt(pkt, ts)
10.176 -64.46%  0.052 writepkt(pkt)
 7.488 -73.85%  0.020 writepkt_time(pkt, ts)
 7.074 -75.29%  0.253 writepkts([(ts, pkt)])
 5.605 -80.42%  0.027 writepkts(buf_list)
```