### PR TITLE
Local tests should run against python3.4, as the travis CI build does.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py35, docs
+envlist = py26, py27, py34, py35, docs
 
 [testenv]
 install_command =


### PR DESCRIPTION
#396 