### PR TITLE
update ip6.py to read all extension headers

### DIFF
--- a/dpkt/ip6.py
+++ b/dpkt/ip6.py
@@ -58,6 +58,7 @@ class IP6(dpkt.Packet):
     def unpack(self, buf):
         dpkt.Packet.unpack(self, buf)
         self.extension_hdrs = {}
+        self.all_extension_headers=[]
 
         if self.plen:
             buf = self.data[:self.plen]
@@ -69,6 +70,7 @@ class IP6(dpkt.Packet):
         while next_ext_hdr in ext_hdrs:
             ext = ext_hdrs_cls[next_ext_hdr](buf)
             self.extension_hdrs[next_ext_hdr] = ext
+            self.all_extension_headers.append(ext)
             buf = buf[ext.length:]
             next_ext_hdr = getattr(ext, 'nxt', None)
 


### PR DESCRIPTION
with current ip6.py, dpkt will escape all extension headers in packet and only read the last extension header in each packet. that mean with current version you are not able see extension headers in a packet except the last one.

**at the moment you only get this**

> <bound method IP6.unpack of IP6(v=6, fc=0, flow=8, plen=1182, nxt=60, hlim=255, src='Src', dst='Dst', p=58, extension_hdrs={60: IP6DstOptsHeader(nxt=58, length=8, options=[{'opt_length': 0, 'data': '', 'type': 31}], data='DATA')}, data=ICMP6(type=128, sum=754, data=Echo(seq=8, data='DATA')))>

**with new code you can read all extension headers**

<img width="2379" alt="screen shot 2017-11-25 at 20 13 38" src="https://user-images.githubusercontent.com/12979893/33234356-7f4c2d6a-d21d-11e7-92ef-a7091193c25e.png">


with this update you are able to count/read all extension headers.

hope this help :)