### PR TITLE
Fix test runner python2.6 dependencies

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = py26, py27, py35, docs
 [testenv]
 install_command =
     pip install {opts} {packages}
+# FIXME: remove version pinning when py26 support is no longer needed
 deps =
     setuptools==36.8.0
     wheel==0.29
@@ -33,4 +34,3 @@ commands =
 changedir=docs
 deps = -rdocs/requirements.txt
 commands = sphinx-build -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
-

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,10 @@ envlist = py26, py27, py35, docs
 install_command =
     pip install {opts} {packages}
 deps =
+    setuptools==36.8.0
+    wheel==0.29
+    pytest==3.2.5
     coverage
-    pytest
     pytest-cov
     stdeb
 commands =


### PR DESCRIPTION
Per #394, three of the test running dependencies (setuptools and wheel are dependencies of pytest) have dropped support for python2.6 recently.

This commit pins to the last version of the dependencies which support python2.6.