### PR TITLE
Support 802.1ad vlan tags, MPLS fixes

### DIFF
--- a/dpkt/ethernet.py
+++ b/dpkt/ethernet.py
@@ -117,10 +117,11 @@ class Ethernet(dpkt.Packet):
             if buf[0] == '\x45':  # IP version 4 + header len 20 bytes
                 next_type = ETH_TYPE_IP
 
-            # pseudowire Ethernet control word (ECW)
-            elif buf[:2] == '\x00\x00' and len(buf) - 4 >= self.__hdr_len__:
-                buf = buf[4:]  # skip the ECW
-                next_type = ETH_TYPE_TEB  # re-use TEB to decode Ethernet
+            # pseudowire Ethernet
+            elif len(buf) >= self.__hdr_len__:
+                if buf[:2] == '\x00\x00':  # looks like the control word (ECW)
+                    buf = buf[4:]  # skip the ECW
+                next_type = ETH_TYPE_TEB  # re-use TEB class mapping to decode Ethernet
 
         try:
             self.data = self._typesw[next_type](buf)


### PR DESCRIPTION
The change addresses 2 issues:
#389 - We're not doing 802.1q and 802.1ad correctly in ethernet.py
#425 - MPLS decoding to support PW ECW

... adds support for 802.1ad (long due), adds a couple new unit tests, and a small fix for incorrect fcs/trailer decoding.  

Work mostly inspired by @smutt 's work on #389 and his PR #390 (which was unfortunately not reviewed for over a year and currently needs extra work to pass tests etc).  I believe I've addressed all of @smutt 's concerns raised in #389.