### PR TITLE
Make licence more precise

### DIFF
--- a/dpkt/__init__.py
+++ b/dpkt/__init__.py
@@ -5,7 +5,7 @@ import sys
 
 __author__ = 'Dug Song'
 __author_email__ = 'dugsong@monkey.org'
-__license__ = 'BSD'
+__license__ = 'BSD-3-Clause'
 __url__ = 'https://github.com/kbandla/dpkt'
 __version__ = '1.9.2'
 


### PR DESCRIPTION
According to SPDX site [1] dpkt is licensed as BSD-3-Clause.

[1] https://spdx.org/licenses/BSD-3-Clause.html