### PR TITLE
Exception with DTP

### DIFF
--- a/dpkt/dtp.py
+++ b/dpkt/dtp.py
@@ -32,6 +32,8 @@ class DTP(dpkt.Packet):
             tvs.append((t, v))
         self.data = tvs
 
+    def __bytes__(self):
+        return b''.join([struct.pack('>HH', t, len(v)) + v for t, v in self.data])
 
 TRUNK_NAME = 0x01
 MAC_ADDR = 0x04

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps =
     wheel==0.29
     pytest==3.2.5
     coverage
-    pytest-cov
+    pytest-cov==2.5.1
     stdeb
 commands =
     py.test --cov=dpkt dpkt


### PR DESCRIPTION
dtp represents `DTP.data` as a list of (type, data). `Packet.__bytes__` was throwing an exception due to this. 

I defined `DTP.__bytes__` that re-packs the `DTP.data` to a `bytearray`

I am not very familiar with DTP, but it seemed the rest of the modules coverts `obj.data` to a `bytearray` by overriding `Packet.__bytes__`.