### PR TITLE
Use `six` package for backwards compatibility

### DIFF
--- a/dpkt/aoe.py
+++ b/dpkt/aoe.py
@@ -4,9 +4,10 @@ from __future__ import absolute_import
 
 import struct
 
+import six
+
 from . import dpkt
 from .decorators import deprecated
-from .compat import iteritems
 
 class AOE(dpkt.Packet):
     """ATA over Ethernet Protocol.
@@ -73,7 +74,7 @@ def __load_cmds():
     prefix = 'AOE_CMD_'
     g = globals()
 
-    for k, v in iteritems(g):
+    for k, v in six.iteritems(g):
         if k.startswith(prefix):
             name = 'aoe' + k[len(prefix):].lower()
             try:

--- a/dpkt/compat.py
+++ b/dpkt/compat.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import sys
 
 if sys.version_info < (3,):
@@ -7,33 +5,3 @@ if sys.version_info < (3,):
 else:
     def compat_ord(char):
         return char
-
-try:
-    from itertools import izip
-    compat_izip = izip
-except ImportError:
-    compat_izip = zip
-
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from io import StringIO
-
-try: 
-    from BytesIO import BytesIO
-except ImportError: 
-    from io import BytesIO
-        
-if sys.version_info < (3,):
-    def iteritems(d, **kw):
-        return d.iteritems(**kw)
-
-    def intround(num):
-        return int(round(num))
-
-else:
-    def iteritems(d, **kw):
-        return iter(d.items(**kw))
-
-    # python3 will return an int if you round to 0 decimal places
-    intround = round

--- a/dpkt/decorators.py
+++ b/dpkt/decorators.py
@@ -2,7 +2,10 @@
 from __future__ import print_function
 from __future__ import absolute_import
 
+import sys
 import warnings
+
+import six.moves
 
 
 def decorator_with_args(decorator_to_enhance):
@@ -48,12 +51,10 @@ class TestDeprecatedDecorator(object):
         return
 
     def test_deprecated_decorator(self):
-        import sys
-        from .compat import StringIO
 
         saved_stderr = sys.stderr
         try:
-            out = StringIO()
+            out = six.moves.StringIO()
             sys.stderr = out
             self.deprecated_decorator()
             try: # This isn't working under newest version of pytest

--- a/dpkt/ethernet.py
+++ b/dpkt/ethernet.py
@@ -8,9 +8,11 @@ from __future__ import absolute_import
 import struct
 from zlib import crc32
 
+import six
+
 from . import dpkt
 from . import llc
-from .compat import compat_ord, iteritems
+from .compat import compat_ord
 
 try:
     isinstance("", basestring)
@@ -266,7 +268,7 @@ class Ethernet(dpkt.Packet):
 # XXX - auto-load Ethernet dispatch table from ETH_TYPE_* definitions
 def __load_types():
     g = globals()
-    for k, v in iteritems(g):
+    for k, v in six.iteritems(g):
         if k.startswith('ETH_TYPE_'):
             name = k[9:]
             modname = name.lower()

--- a/dpkt/gre.py
+++ b/dpkt/gre.py
@@ -3,13 +3,14 @@
 """Generic Routing Encapsulation."""
 from __future__ import absolute_import
 
-import struct
 import codecs
+import struct
+
+import six.moves
 
 from . import dpkt
 from . import ethernet
 from .decorators import deprecated
-from .compat import compat_izip
 
 GRE_CP = 0x8000  # Checksum Present
 GRE_RP = 0x4000  # Routing Present
@@ -88,7 +89,7 @@ class GRE(dpkt.Packet):
             fmtlen = struct.calcsize(fmt)
             vals = struct.unpack("!" + fmt, self.data[:fmtlen])
             self.data = self.data[fmtlen:]
-            self.__dict__.update(dict(compat_izip(fields, vals)))
+            self.__dict__.update(dict(six.moves.zip(fields, vals)))
         if self.flags & GRE_RP:
             l = []
             while True:

--- a/dpkt/ip.py
+++ b/dpkt/ip.py
@@ -4,9 +4,10 @@
 from __future__ import print_function
 from __future__ import absolute_import
 
+import six
+
 from . import dpkt
 from .decorators import deprecated
-from .compat import iteritems
 
 class IP(dpkt.Packet):
     """Internet Protocol.
@@ -327,7 +328,7 @@ IP_PROTO_MAX = 255
 
 def __load_protos():
     g = globals()
-    for k, v in iteritems(g):
+    for k, v in six.iteritems(g):
         if k.startswith('IP_PROTO_'):
             name = k[9:].lower()
             try:

--- a/dpkt/netflow.py
+++ b/dpkt/netflow.py
@@ -6,8 +6,9 @@ from __future__ import absolute_import
 
 import struct
 
+import six.moves
+
 from . import dpkt
-from .compat import compat_izip
 
 class NetflowBase(dpkt.Packet):
     """Base class for Cisco Netflow packets.
@@ -66,8 +67,9 @@ class NetflowBase(dpkt.Packet):
 
         def unpack(self, buf):
             # don't bother with data
-            for k, v in compat_izip(self.__hdr_fields__,
-                                       struct.unpack(self.__hdr_fmt__, buf[:self.__hdr_len__])):
+            for k, v in six.moves.zip(self.__hdr_fields__,
+                                      struct.unpack(self.__hdr_fmt__,
+                                      buf[:self.__hdr_len__])):
                 setattr(self, k, v)
             self.data = b""
 

--- a/dpkt/pcap.py
+++ b/dpkt/pcap.py
@@ -4,12 +4,13 @@
 from __future__ import print_function
 from __future__ import absolute_import
 
+from decimal import Decimal
 import sys
 import time
-from decimal import Decimal
+
+import six
 
 from . import dpkt
-from .compat import intround
 
 TCPDUMP_MAGIC = 0xa1b2c3d4
 TCPDUMP_MAGIC_NANO = 0xa1b23c4d
@@ -236,7 +237,7 @@ class Writer(object):
         """
         n = len(pkt)
         sec = int(ts)
-        usec = intround(ts % 1 * self._precision_multiplier)
+        usec = int(round(ts % 1 * self._precision_multiplier))
         ph = self._pack_hdr(sec, usec, n, n)
         self.__f.write(ph + pkt)
 
@@ -256,7 +257,7 @@ class Writer(object):
         for ts, pkt in pkts:
             n = len(pkt)
             sec = int(ts)
-            usec = intround(ts % 1 * precision_multiplier)
+            usec = int(round(ts % 1 * precision_multiplier))
             ph = pack_hdr(sec, usec, n, n)
             fd.write(ph + pkt)
 
@@ -370,12 +371,10 @@ def test_reader():
     )
 
     # --- BytesIO tests ---
-    from .compat import BytesIO
 
     # BytesIO
-    fobj = BytesIO(data)
+    fobj = six.BytesIO(data)
     reader = Reader(fobj)
-    assert reader.name == '<BytesIO>'
     _, buf1 = next(iter(reader))
     assert buf1 == data[FileHdr.__hdr_len__ + PktHdr.__hdr_len__:]
 
@@ -412,9 +411,8 @@ class WriterTestWrap:
 
     def __call__(self, f, *args, **kwargs):
         def wrapper(*args, **kwargs):
-            from .compat import BytesIO
             for little_endian in [True, False]:
-                fobj = BytesIO()
+                fobj = six.BytesIO()
                 _sysle = Writer._Writer__le
                 Writer._Writer__le = little_endian
                 f.__globals__['writer'] = Writer(fobj, **self.kwargs.get('writer', {}))

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,11 @@ except ImportError:
 
 package_name = 'dpkt'
 description = 'fast, simple packet creation / parsing, with definitions for the basic TCP/IP protocols'
-readme = open('README.rst').read()
-requirements = []
+with open('README.rst') as filep:
+    readme = filep.read()
+requirements = [
+    'six'
+]
 
 # PyPI Readme
 long_description = open('README.rst').read()

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ deps =
     pytest==3.2.5
     coverage
     pytest-cov==2.5.1
+    six
     stdeb
 commands =
     py.test --cov=dpkt dpkt
@@ -25,6 +26,7 @@ commands =
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 deps =
     coveralls
+    six
 usedevelop = true
 commands =
     coverage report


### PR DESCRIPTION
The `six` package provides a number of backwards compatible hooks for
moved/renamed APIs. It's better to use their APIs than reinvent the wheel.

While this doesn't completely remove the need for dpkt/compat.py, it
largely eliminates this need. Removing/replacing `compat_ord` and
remaining backwards compatible between python 2.7 and python 3.7 proved
to be more of a challenge than I was willing to commit to for this
change.

Signed-off-by: Enji Cooper <yaneurabeya@gmail.com>