### PR TITLE
release 1.9.3 (#453)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,10 @@ matrix:
       env: TOXENV=py36
     - python: "3.7"
       env: TOXENV=py37,coveralls,docs
-    - python: "pypy3.5"
-      env: TOXENV=pypy
     - python: "3.8"
       env: TOXENV=py38
+    - python: "pypy3.5"
+      env: TOXENV=pypy
 before_install:
   - python --version
   - virtualenv --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
       env: TOXENV=py37,coveralls,docs
     - python: "pypy3.5"
       env: TOXENV=pypy
+    - python: "3.8"
+      env: TOXENV=py38
 before_install:
   - python --version
   - virtualenv --version
@@ -28,4 +30,3 @@ notifications:
   email:
     on_success: never
     on_failure: always
-

--- a/AUTHORS
+++ b/AUTHORS
@@ -60,8 +60,8 @@ Tim Yardley <yardley@gmail.com>
 	DHCP definitions
 
 obormot <oscar.ibatullin@gmail.com>
-	pcapng module, Packet repr improvements
-	
+	pcapng module, Ethernet, core improvements
+
 Kyle Keppler <kyle.keppler@gmail.com>
 	Python 3 port
 

--- a/dpkt/__init__.py
+++ b/dpkt/__init__.py
@@ -7,7 +7,7 @@ __author__ = 'Dug Song'
 __author_email__ = 'dugsong@monkey.org'
 __license__ = 'BSD-3-Clause'
 __url__ = 'https://github.com/kbandla/dpkt'
-__version__ = '1.9.2'
+__version__ = '1.9.3'
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,9 @@
-import os
 import sys
 
 try:
-    from setuptools import setup, Command
+    from setuptools import setup
 except ImportError:
-    from distutils.core import setup, Command
+    from distutils.core import setup
 
 package_name = 'dpkt'
 description = 'fast, simple packet creation / parsing, with definitions for the basic TCP/IP protocols'
@@ -42,6 +41,7 @@ setup(name=package_name,
           'Programming Language :: Python :: 3.5',
           'Programming Language :: Python :: 3.6',
           'Programming Language :: Python :: 3.7',
+          'Programming Language :: Python :: 3.8',
           'Programming Language :: Python :: Implementation :: CPython',
           'Programming Language :: Python :: Implementation :: PyPy',
       ]

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
     wheel
     pytest==3.2.5
     coverage
-    pytest-cov
+    pytest-cov==2.5.1
     stdeb
 commands =
     py.test --cov=dpkt dpkt

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ install_command =
 deps =
     setuptools
     wheel
-    pytest
+    pytest==3.2.5
     coverage
     pytest-cov
     stdeb

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,15 @@
 [tox]
-envlist = py27, py35, py36, py37, docs
+envlist = py27, py35, py36, py37, py38, docs
 
 [testenv]
 install_command =
     pip install {opts} {packages}
-# FIXME: remove version pinning when py26 support is no longer needed
 deps =
-    setuptools==36.8.0
-    wheel==0.29
-    pytest==3.2.5
+    setuptools
+    wheel
+    pytest
     coverage
-    pytest-cov==2.5.1
+    pytest-cov
     stdeb
 commands =
     py.test --cov=dpkt dpkt


### PR DESCRIPTION
**!not tested on testpypi -- do not merge yet!**

this PR is drafting 1.9.3 release
- branched from the latest master
- dropping pinned package versions that were required for py2.6 support and no longer needed
- added py3.8 compatibility

@brifordwylie could you please review and push this forward when you have time? 
I've followed your guide for the release (the "admin" guide), however it turned out testpypi has separate accounts from the main pypi so I can't push there.

UPDATE: created a test push under a new project name https://test.pypi.org/project/dpkt-testing2/