### PR TITLE
ipv6 option unpack: use byte length in the loop

### DIFF
--- a/dpkt/ip6.py
+++ b/dpkt/ip6.py
@@ -155,7 +155,7 @@ class IP6OptsHeader(IP6ExtensionHeader):
 
         index = 0
 
-        while index < self.length - 2:
+        while index < self.len - 2:
             opt_type = compat_ord(self.data[index])
 
             # PAD1 option


### PR DESCRIPTION
self.length is the _bit_ length of the OptsHeader, while in the while loop, we need _byte_ length.

Attempt to continue the loop beyond the data size eventually results in IndexError exception.

This should fix the issue #477 