### PR TITLE
Adding Power support(ppc64le) with ci and testing to the project for architecture independent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,21 @@ matrix:
       env: TOXENV=py38
     - python: "pypy3.5"
       env: TOXENV=pypy
+    - python: "2.7"
+      arch: ppc64le
+      env: TOXENV=py27
+    - python: "3.5"
+      arch: ppc64le
+      env: TOXENV=py35
+    - python: "3.6"
+      arch: ppc64le
+      env: TOXENV=py36
+    - python: "3.7"
+      arch: ppc64le
+      env: TOXENV=py37,coveralls,docs
+    - python: "3.8"
+      arch: ppc64le
+      env: TOXENV=py38
 before_install:
   - python --version
   - virtualenv --version


### PR DESCRIPTION
I am working for IBM to port cpu arch ppc64le for open sources.

This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro 
on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date.


This helps us simplify testing later when distributions are re-building and re-releasing,We typically build applications for customers and 
ISVs, and while we don't use this package directly,we do count on all of the packages in debian/ubuntu to build other packages. So we more likely have this as a second or 
third level dependency and couldn't tell you explicitly which features we use or our usage model,For more info tag @gerrith3.

Please help to verify and merge.