### PR TITLE
Big endian arch bugfixes

### DIFF
--- a/dpkt/compat.py
+++ b/dpkt/compat.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-import struct
+from struct import pack, unpack
 import sys
 
 if sys.version_info < (3,):
@@ -40,9 +40,8 @@ else:
     intround = round
 
 
-def ntole(fmt, v):
-    """convert a 2-byte word (fmt='H') or a 4-byte integer (fmt='I')
-    from the network byte order (big endian) to little endian;
+def ntole(v):
+    """convert a 2-byte word from the network byte order (big endian) to little endian;
     replaces socket.ntohs() to work on both little and big endian architectures
     """
-    return struct.unpack('<' + fmt, struct.pack('!' + fmt, v))[0]
+    return unpack('<H', pack('!H', v))[0]

--- a/dpkt/compat.py
+++ b/dpkt/compat.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import struct
 import sys
 
 if sys.version_info < (3,):
@@ -19,9 +20,9 @@ try:
 except ImportError:
     from io import StringIO
 
-try: 
+try:
     from BytesIO import BytesIO
-except ImportError: 
+except ImportError:
     from io import BytesIO
 
 if sys.version_info < (3,):
@@ -37,3 +38,11 @@ else:
 
     # python3 will return an int if you round to 0 decimal places
     intround = round
+
+
+def ntole(fmt, v):
+    """convert a 2-byte word (fmt='H') or a 4-byte integer (fmt='I')
+    from the network byte order (big endian) to little endian;
+    replaces socket.ntohs() to work on both little and big endian architectures
+    """
+    return struct.unpack('<' + fmt, struct.pack('!' + fmt, v))[0]

--- a/dpkt/dpkt.py
+++ b/dpkt/dpkt.py
@@ -1,12 +1,10 @@
 # $Id: dpkt.py 43 2007-08-02 22:42:59Z jon.oberheide $
 # -*- coding: utf-8 -*-
 """Simple packet creation and parsing."""
-from __future__ import absolute_import 
+from __future__ import absolute_import
 
 import copy
-import socket
 import struct
-import array
 from functools import partial
 
 from .compat import compat_ord, compat_izip, iteritems
@@ -48,7 +46,7 @@ class Packet(_MetaPacket("Temp", (object,), {})):
     """Base packet class, with metaclass magic to generate members from self.__hdr__.
 
     Attributes:
-        __hdr__: Packet header should be defined as a list of 
+        __hdr__: Packet header should be defined as a list of
                  (name, structfmt, default) tuples.
         __byte_order__: Byte order, can be set to override the default ('>')
 
@@ -146,7 +144,7 @@ class Packet(_MetaPacket("Temp", (object,), {})):
 
     def __str__(self):
         return str(self.__bytes__())
-    
+
     def __bytes__(self):
         return self.pack_hdr() + bytes(self.data)
 
@@ -200,16 +198,19 @@ def hexdump(buf, length=16):
 def in_cksum_add(s, buf):
     n = len(buf)
     cnt = (n // 2) * 2
-    a = array.array('H', buf[:cnt])
+    a = struct.unpack('<{}H'.format(n // 2), buf[:cnt])  # unpack as little endian words
+    res = s + sum(a)
     if cnt != n:
-        a.append(compat_ord(buf[-1]))
-    return s + sum(a)
+        res += compat_ord(buf[-1])
+    return res
 
 
 def in_cksum_done(s):
     s = (s >> 16) + (s & 0xffff)
     s += (s >> 16)
-    return socket.ntohs(~s & 0xffff)
+    res = ~s & 0xffff
+    # convert from the network order to little endian
+    return struct.unpack('<H', struct.pack('!H', res))[0]
 
 
 def in_cksum(buf):
@@ -222,8 +223,10 @@ def test_utils():
     __hd = '  0000:  00 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e     ...............'
     h = hexdump(__buf)
     assert (h == __hd)
+    assert in_cksum_add(0, __buf) == 12600  # endianness
     c = in_cksum(__buf)
     assert (c == 51150)
+
 
 def test_getitem():
     """ create a Packet subclass and access its properties """
@@ -244,6 +247,7 @@ def test_getitem():
     except Exception as e:
         assert isinstance(e, KeyError)
 
+
 def test_pack_hdr_overflow():
     """ Try to fit too much data into struct packing """
     class Foo(Packet):
@@ -260,6 +264,7 @@ def test_pack_hdr_overflow():
     else:
         assert False, "There should have been an exception raised"
 
+
 def test_pack_hdr_tuple():
     """ Test the unpacking of a tuple for a single format string """
     class Foo(Packet):
@@ -270,4 +275,3 @@ def test_pack_hdr_tuple():
     foo = Foo()
     b = bytes(foo)
     assert b == b'\x00\x00\x00\x01\x00\x00\x00\x02'
-

--- a/dpkt/dpkt.py
+++ b/dpkt/dpkt.py
@@ -7,7 +7,7 @@ import copy
 import struct
 from functools import partial
 
-from .compat import compat_ord, compat_izip, iteritems
+from .compat import compat_ord, compat_izip, iteritems, ntole
 
 
 class Error(Exception):
@@ -208,9 +208,7 @@ def in_cksum_add(s, buf):
 def in_cksum_done(s):
     s = (s >> 16) + (s & 0xffff)
     s += (s >> 16)
-    res = ~s & 0xffff
-    # convert from the network order to little endian
-    return struct.unpack('<H', struct.pack('!H', res))[0]
+    return ntole('H', ~s & 0xffff)
 
 
 def in_cksum(buf):

--- a/dpkt/dpkt.py
+++ b/dpkt/dpkt.py
@@ -208,7 +208,7 @@ def in_cksum_add(s, buf):
 def in_cksum_done(s):
     s = (s >> 16) + (s & 0xffff)
     s += (s >> 16)
-    return ntole('H', ~s & 0xffff)
+    return ntole(~s & 0xffff)
 
 
 def in_cksum(buf):

--- a/dpkt/ieee80211.py
+++ b/dpkt/ieee80211.py
@@ -765,7 +765,7 @@ def test_action_block_ack_request():
     assert ieee.action.category == BLOCK_ACK
     assert ieee.action.code == BLOCK_ACK_CODE_REQUEST
     assert ieee.action.block_ack_request.timeout == 0
-    parameters = struct.unpack('H', b'\x10\x02')[0]
+    parameters = struct.unpack('<H', b'\x10\x02')[0]
     assert ieee.action.block_ack_request.parameters == parameters
 
 def test_action_block_ack_response():
@@ -775,9 +775,9 @@ def test_action_block_ack_response():
     assert ieee.subtype == M_ACTION
     assert ieee.action.category == BLOCK_ACK
     assert ieee.action.code == BLOCK_ACK_CODE_RESPONSE
-    timeout = struct.unpack('H', b'\x13\x88')[0]
+    timeout = struct.unpack('<H', b'\x13\x88')[0]
     assert ieee.action.block_ack_response.timeout == timeout
-    parameters = struct.unpack('H', b'\x10\x02')[0]
+    parameters = struct.unpack('<H', b'\x10\x02')[0]
     assert ieee.action.block_ack_response.parameters == parameters
 
 if __name__ == '__main__':

--- a/dpkt/ieee80211.py
+++ b/dpkt/ieee80211.py
@@ -363,7 +363,7 @@ class IEEE80211(dpkt.Packet):
         if self.type == MGMT_TYPE:
             self.unpack_ies(field.data)
             if self.subtype in FRAMES_WITH_CAPABILITY:
-                self.capability = self.Capability(ntole('H', field.capability))
+                self.capability = self.Capability(ntole(field.capability))
 
         if self.type == DATA_TYPE and self.subtype == D_QOS_DATA:
             self.qos_data = self.QoS_Data(field.data)
@@ -422,7 +422,7 @@ class IEEE80211(dpkt.Packet):
         def unpack(self, buf):
             dpkt.Packet.unpack(self, buf)
             self.data = buf[self.__hdr_len__:]
-            self.ctl = ntole('H', self.ctl)
+            self.ctl = ntole(self.ctl)
 
             if self.compressed:
                 self.bmp = struct.unpack('8s', self.data[0:_COMPRESSED_BMP_LENGTH])[0]

--- a/dpkt/pcapng.py
+++ b/dpkt/pcapng.py
@@ -1241,6 +1241,9 @@ def test_writepkts():
     writer.writepkts(pkts)
     return pkts
 
+def test_pcapng_block_pack():
+    assert bytes(_PcapngBlock())
+
 def test_pcapng_block_unpack():
     block = _PcapngBlock()
     buf = b'012345678901'

--- a/dpkt/pcapng.py
+++ b/dpkt/pcapng.py
@@ -1112,7 +1112,10 @@ def test_custom_read_write():
     fobj.close()
 
     # test pcapng customized writing
-    shb, idb, epb = define_testdata().shb_idb_epb_le
+    if sys.byteorder == 'little':
+        shb, idb, epb = define_testdata().shb_idb_epb_le
+    else:
+        shb, idb, epb = define_testdata().shb_idb_epb_be
 
     fobj = BytesIO()
     writer = Writer(fobj, shb=shb, idb=idb)

--- a/dpkt/radiotap.py
+++ b/dpkt/radiotap.py
@@ -3,10 +3,9 @@
 from __future__ import print_function
 from __future__ import absolute_import
 
-import socket
-
 from . import dpkt
 from . import ieee80211
+from .compat import ntole
 
 # Ref: http://www.radiotap.org
 # Fields Ref: http://www.radiotap.org/defined-fields/all
@@ -234,7 +233,7 @@ class Radiotap(dpkt.Packet):
 
     def unpack(self, buf):
         dpkt.Packet.unpack(self, buf)
-        self.data = buf[socket.ntohs(self.length):]
+        self.data = buf[ntole('H', self.length):]
 
         self.fields = []
         buf = buf[self.__hdr_len__:]

--- a/dpkt/radiotap.py
+++ b/dpkt/radiotap.py
@@ -233,7 +233,7 @@ class Radiotap(dpkt.Packet):
 
     def unpack(self, buf):
         dpkt.Packet.unpack(self, buf)
-        self.data = buf[ntole('H', self.length):]
+        self.data = buf[ntole(self.length):]
 
         self.fields = []
         buf = buf[self.__hdr_len__:]


### PR DESCRIPTION
As was highlighted in #505 some unit tests were failing on IBM System Z, which is a big endian architecture. 
I've reproduced all the failures on QEMU PowerPC VM which is also big endian. In most cases the failures were due to decoders using `socket.ntohs()` to convert from network byte order to host byte order, assuming host is little endian (x86).
On BE systems the function didn't actually convert since the host itself is BE, producing incorrect fields in the decoders.
This patch introduces `compat.ntole()` function which always converts from network order to LE and works consistently on both LE and BE systems. 