### PR TITLE
Testing ssl

### DIFF
--- a/dpkt/ssl.py
+++ b/dpkt/ssl.py
@@ -804,8 +804,6 @@ class TestTLSCertificate(object):
 
 class TestTLSMultiFactory(object):
     """Made up test data"""
-    import pytest
-
     @classmethod
     def setup_class(cls):
         cls.data = _hexdecode(b'1703010010'  # header 1
@@ -831,6 +829,8 @@ class TestTLSMultiFactory(object):
         assert (self.msgs[1].data == _hexdecode(b'BB' * 16))
 
     def test_incomplete(self):
+        import pytest
+
         msgs, n = tls_multi_factory(_hexdecode(b'17'))
         assert (len(msgs) == 0)
         assert (n == 0)
@@ -847,7 +847,7 @@ class TestTLSMultiFactory(object):
         assert (len(msgs) == 1)
         assert (n == 5)
 
-        with self.pytest.raises(SSL3Exception, match='Bad TLS version in buf: '):
+        with pytest.raises(SSL3Exception, match='Bad TLS version in buf: '):
             tls_multi_factory(_hexdecode(b'000000000000'))
 
 


### PR DESCRIPTION
Extending testing of `ssl.py` to cover SSL2 class. Note that the `msg` and `pad` elements of `__hdr__` have been removed as the superclass unpacking would extract a single element from the buffer, setting `.data` incorrectly.

They are now only created during the class's `unpack` method.

Other tests are to exercise the exception handling in class unpackings.