### PR TITLE
Remove unreachable exception handling in ip6.py

### DIFF
--- a/dpkt/ip6.py
+++ b/dpkt/ip6.py
@@ -120,10 +120,8 @@ class IP6(dpkt.Packet):
             s = struct.pack('>16s16sxBH', self.src, self.dst, self.p, len(p))
             s = dpkt.in_cksum_add(0, s)
             s = dpkt.in_cksum_add(s, p)
-            try:
-                self.data.sum = dpkt.in_cksum_done(s)
-            except AttributeError:
-                pass
+            self.data.sum = dpkt.in_cksum_done(s)
+
         return self.pack_hdr() + hdr_str + bytes(self.data)
 
     @classmethod


### PR DESCRIPTION
During packing of IP6 instances, it does not appear to be possible to raise an AttributeError during this section of code.

 - The `if` statement on line 117 already reads `self.data.sum`
 - No attributes are accessed by `dpkt.in_cksum_done`.

It is possible that `self.data.sum` could be read-only, which would raise an `AttributeError` when trying to write to it.

I cannot think of a way to generate this exception, so we should remove the code, or design a test for it.