### PR TITLE
Implement coveralls as Github Action

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -23,16 +23,37 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest coverage pytest-cov
+
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+
     - name: Test with pytest
       run: |
         pytest dpkt
+        coverage run --source dpkt/ -m pytest dpkt/
+        coverage report -m
+
+    - name: Coveralls Python
+      uses: AndreMiras/coveralls-python-action@v20201129
+      with:
+        parallel: true
+        flag-name: Unit Test - Python ${{ matrix.python-version }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  coveralls_finish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Push to Coveralls
+      uses: AndreMiras/coveralls-python-action@develop
+      with:
+        parallel-finished: true

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,9 @@ changedir=docs
 deps = -rdocs/requirements.txt
 commands = sphinx-build -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 
+[coverage:run]
+relative_files = True
+
 [coverage:report]
 exclude_lines =
     @abstractmethod


### PR DESCRIPTION
An option to address lack of code coverage after deprecating Travis.

This improves on the previous implementation by combining the coverage reports from all of the test runs into a single report. This means that we have 100% coverage of compat.py as the coverage report from python2.7 is also included.

There's a bug somewhere that means that only the python 3.8 run recognises property function definitions as having been run, despite the function body having coverage (example: https://coveralls.io/jobs/74694339/source_files/5716953912)

Coveralls currently reports the aggregated coverage as 99.812%, which is pretty nice.