### PR TITLE
added a check in sctp.unpack to prevent exception

### DIFF
--- a/dpkt/sctp.py
+++ b/dpkt/sctp.py
@@ -51,7 +51,7 @@ class SCTP(dpkt.Packet):
         while self.data:
             chunk = Chunk(self.data)
             l_.append(chunk)
-            if len(chunk) == 0 or len(chunk) >= len(self.data):
+            if len(chunk) == 0:
                 break
             self.data = self.data[len(chunk):]
         self.chunks = l_

--- a/dpkt/sctp.py
+++ b/dpkt/sctp.py
@@ -51,6 +51,8 @@ class SCTP(dpkt.Packet):
         while self.data:
             chunk = Chunk(self.data)
             l_.append(chunk)
+            if len(chunk) == 0 or len(chunk) >= len(self.data):
+                break
             self.data = self.data[len(chunk):]
         self.chunks = l_
 


### PR DESCRIPTION
when unpack is parsing a malformed sctp packet with improperly labeled chunk size, it will either infinitely loop (if size is labeled as 0), or throw an out of bounds exception (if listed size is larger than the real chunk size)