### PR TITLE
Fix dpkg.dns.pack_name.

### DIFF
--- a/dpkt/dns.py
+++ b/dpkt/dns.py
@@ -75,7 +75,7 @@ def pack_name(name, off, label_ptrs):
     for i, label in enumerate(labels):
         key = b'.'.join(labels[i:]).upper()
         ptr = label_ptrs.get(key)
-        if not ptr:
+        if ptr is None:
             if len(key) > 1:
                 ptr = off + len(buf)
                 if ptr < 0xc000:


### PR DESCRIPTION
Testing the result of label_ptrs.get(key) only for truthness is
missing 0 as a valid offset.  The result must be tested for identity
with None instead.