### PR TITLE
Fix #587

### DIFF
--- a/dpkt/ssl.py
+++ b/dpkt/ssl.py
@@ -299,7 +299,7 @@ class TLSClientHello(dpkt.Packet):
         pointer += parsed
         num_ciphersuites = int(len(ciphersuites) / 2)
         self.ciphersuites = [
-            ssl_ciphersuites.BY_CODE.get(code, ssl_ciphersuites.UnknownCipherSuite(code))
+            ssl_ciphersuites.BY_CODE.get(code, ssl_ciphersuites.get_unknown_ciphersuite(code))
             for code in struct.unpack('!' + num_ciphersuites * 'H', ciphersuites)]
         # check len(ciphersuites) % 2 == 0 ?
 
@@ -327,7 +327,7 @@ class TLSServerHello(dpkt.Packet):
             # single cipher suite
             code = struct.unpack('!H', self.data[pointer:pointer + 2])[0]
             self.ciphersuite = \
-                ssl_ciphersuites.BY_CODE.get(code, ssl_ciphersuites.UnknownCipherSuite(code))
+                ssl_ciphersuites.BY_CODE.get(code, ssl_ciphersuites.get_unknown_ciphersuite(code))
             pointer += 2
 
             # single compression method
@@ -904,7 +904,7 @@ def test_clienthello_invalidcipher():
         '00'
     )
     th = TLSClientHello(buf)
-    assert isinstance(th.ciphersuites[0], ssl_ciphersuites.UnknownCipherSuite)
+    assert th.ciphersuites[0].name == 'Unknown'
 
 
 def test_serverhello_invalidcipher():
@@ -923,7 +923,7 @@ def test_serverhello_invalidcipher():
         '00'
     )
     th = TLSServerHello(buf)
-    assert isinstance(th.cipher_suite, ssl_ciphersuites.UnknownCipherSuite)
+    assert th.ciphersuite.name == 'Unknown'
 
     # remove the final byte from the ciphersuite so it will fail unpacking
     buf = buf[:-1]

--- a/dpkt/ssl_ciphersuites.py
+++ b/dpkt/ssl_ciphersuites.py
@@ -725,7 +725,9 @@ class TestCipherSuites(object):
 
     def test_repr(self):
         cs = CipherSuite(0x0009, 'RSA', '         ', 'DES     ', 'CBC ', 'SHA')
-        assert repr(cs) == "CipherSuite(TLS_RSA_WITH_DES_CBC_SHA)"
+        assert repr(cs) == "CipherSuite(0x0009, TLS_RSA_WITH_DES_CBC_SHA)"
 
         assert cs.mac_size == 20
         assert cs.block_size == 8
+
+        repr(BY_CODE[0x6a6a]) == "CipherSuite(0x6a6a, GREASE)"

--- a/dpkt/ssl_ciphersuites.py
+++ b/dpkt/ssl_ciphersuites.py
@@ -132,6 +132,14 @@ class CipherSuite(object):
         return self.auth.startswith('anon')
 
 
+class UnknownCipherSuite(object):
+    def __init__(self, code):
+        self.code = code
+
+    def __repr__(self):
+        return 'UnknownCipherSuite(0x%04x)' % self.code
+
+
 # master list of CipherSuite Objects
 # Full list from IANA:
 #   https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml

--- a/dpkt/ssl_ciphersuites.py
+++ b/dpkt/ssl_ciphersuites.py
@@ -83,7 +83,7 @@ class CipherSuite(object):
             return self._name
 
     def __repr__(self):
-        return 'CipherSuite(%s)' % self.name
+        return 'CipherSuite(0x%04x, %s)' % (self.code, self.name)
 
     MAC_SIZES = {
         'MD5': 16,
@@ -132,12 +132,8 @@ class CipherSuite(object):
         return self.auth.startswith('anon')
 
 
-class UnknownCipherSuite(object):
-    def __init__(self, code):
-        self.code = code
-
-    def __repr__(self):
-        return 'UnknownCipherSuite(0x%04x)' % self.code
+def get_unknown_ciphersuite(code):
+    return CipherSuite(code, '', '', '', '', '', name='Unknown')
 
 
 # master list of CipherSuite Objects
@@ -564,6 +560,24 @@ CIPHERSUITES = [
     CipherSuite(0xccac, 'ECDHE', 'PSK    ', 'CHACHA20', 'POLY1305', 'SHA256'),
     CipherSuite(0xccad, 'DHE  ', 'PSK    ', 'CHACHA20', 'POLY1305', 'SHA256'),
     CipherSuite(0xccae, 'RSA  ', 'PSK    ', 'CHACHA20', 'POLY1305', 'SHA256'),
+
+    # RFC8701  // GREASE (Generate Random Extensions And Sustain Extensibility)
+    CipherSuite(0x0a0a, '', '', '', '', '', 'GREASE'),
+    CipherSuite(0x1a1a, '', '', '', '', '', 'GREASE'),
+    CipherSuite(0x2a2a, '', '', '', '', '', 'GREASE'),
+    CipherSuite(0x3a3a, '', '', '', '', '', 'GREASE'),
+    CipherSuite(0x4a4a, '', '', '', '', '', 'GREASE'),
+    CipherSuite(0x5a5a, '', '', '', '', '', 'GREASE'),
+    CipherSuite(0x6a6a, '', '', '', '', '', 'GREASE'),
+    CipherSuite(0x7a7a, '', '', '', '', '', 'GREASE'),
+    CipherSuite(0x8a8a, '', '', '', '', '', 'GREASE'),
+    CipherSuite(0x9a9a, '', '', '', '', '', 'GREASE'),
+    CipherSuite(0xaaaa, '', '', '', '', '', 'GREASE'),
+    CipherSuite(0xbaba, '', '', '', '', '', 'GREASE'),
+    CipherSuite(0xcaca, '', '', '', '', '', 'GREASE'),
+    CipherSuite(0xdada, '', '', '', '', '', 'GREASE'),
+    CipherSuite(0xeaea, '', '', '', '', '', 'GREASE'),
+    CipherSuite(0xfafa, '', '', '', '', '', 'GREASE'),
 
     # Unassigned: 0xccaf-0xfefd
     # Reserved: 0xfefe-0xffff


### PR DESCRIPTION
Improvements to TLS ClientHello and ServerHello parsing:
1. return an "Unknown" ciphersuite instead of raising an exception;
2. add codes for RFC8701, GREASE ciphersutes;
3. CipherSuite `__repr__` now includes the numerical code;
4. rename a couple attributes to align between ClientHello and ServerHello classes, original names still supported.

Examples:
```python
ciphersuites=[
      CipherSuite(0x4a4a, GREASE),                     # old behavior: raise an exception, issue #587
      CipherSuite(0x1301, TLS_AES_128_GCM_SHA256),    # old behavior: CipherSuite(TLS_AES_128_GCM_SHA256)
      CipherSuite(0x001c, Unknown),                  # old behavior: raise an exception
      ...
]
```