### PR TITLE
Proto bit fields

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -59,8 +59,8 @@ Jirka Vejrazka
 Tim Yardley <yardley@gmail.com>
 	DHCP definitions
 
-obormot <oscar.ibatullin@gmail.com>
-	pcapng module, Ethernet, core improvements
+Oscar Ibatullin <oscar.ibatullin@gmail.com>
+	pcapng module, core improvements, bit fields, pretty print, creating parsers doc
 
 Kyle Keppler <kyle.keppler@gmail.com>
 	Python 3 port

--- a/docs/creating_parsers.rst
+++ b/docs/creating_parsers.rst
@@ -104,6 +104,15 @@ Here is the breakdown:
    Similarly to the naming rules of ``__hdr__``, a bit field name starting with an
    underscore is made invisible in the output.
 
+   When dpkt processes ``__bit_fields__`` it auto-creates class properties that
+   enable interfacing with the bit fields directly, specifically: get the value
+   (``ip.v``), modify the value (``ip.v = 6``), and reset the value back to its
+   default (``del ip.v``).
+
+   In certain cases, auto-properties can't be applied; they still can be created
+   explicitly. Look at ``class SMB`` inside ``dpkt/smb.py`` in how it decodes the
+   ``pid`` protocol field.
+
 4. Next, ``__pprint_funcs__`` is an optional dict that does not control protocol
    decoding, but helps with pretty printing of the decoded packet using the ``pprint()``
    method. Each key in this map is a name of the protocol field, and each value is a

--- a/docs/creating_parsers.rst
+++ b/docs/creating_parsers.rst
@@ -26,16 +26,16 @@ Let's look at the IPv4 parser, defined in ``dpkt/ip.py``, as an example.
             ('dst', '4s', b'\x00' * 4)
         )
         __bit_fields__ = {
-            '_v_hl': [
+            '_v_hl': (
                 ('v', 4),   # version, 4 bits
                 ('hl', 4),  # header len, 4 bits
-            ],
-            '_flags_offset': [
+            ),
+            '_flags_offset': (
                 ('rf', 1),  # reserved bit
                 ('df', 1),  # don't fragment
                 ('mf', 1),  # more fragments
-                ('offset', 13)  # fragment offset, 13 bits
-            ]
+                ('offset', 13),  # fragment offset, 13 bits
+            )
         }
         __pprint_funcs__ = {
             'dst': inet_to_str,

--- a/docs/creating_parsers.rst
+++ b/docs/creating_parsers.rst
@@ -74,7 +74,8 @@ Here is the breakdown:
 
      *Examples:*
        - ``_foo_bar_m_flag`` will map to fields named ``foo``, ``bar``, ``m_flag``,
-         when the class contains properties with these names.
+         when the class contains properties with these names (note ``foo_bar_m`` will
+         be ignored since it contains two underscores).
 
        - In the IP class the ``_v_hl`` field itself is hidden in the output of
          ``__repr__`` and ``pprint()``, and is decoded into ``v`` and ``hl`` fields
@@ -85,7 +86,7 @@ Here is the breakdown:
    field will decode to an unsigned byte, ``'H'`` - to an unsigned word, etc.
    The default byte order is big endian (network order). The endianness can be
    changed to little endian by specifying ``__byte_order__ = '<'`` in the class
-   definition, or for each individual field (e.g. ``'<H'``).
+   definition.
 
 3. Next, ``__bit_fields__`` is an optional dict that helps decode compound protocol
    fields, such as ``_v_hl`` or ``_flags_offset`` in the IP class.

--- a/docs/creating_parsers.rst
+++ b/docs/creating_parsers.rst
@@ -1,0 +1,219 @@
+=================================================
+Key concepts of creating protocol parsers in dpkt
+=================================================
+by Oscar Ibatullin [https://github.com/obormot] a contributor/maintainer of dpkt.
+
+Parser class definition
+***********************
+
+Let's look at the IPv4 parser, defined in ``dpkt/ip.py``, as an example.
+
+::
+
+    class IP(dpkt.Packet):
+        """Internet Protocol."""
+
+        __hdr__ = (
+            ('_v_hl', 'B', (4 << 4) | (20 >> 2)),
+            ('tos', 'B', 0),
+            ('len', 'H', 20),
+            ('id', 'H', 0),
+            ('_flags_offset', 'H', 0),
+            ('ttl', 'B', 64),
+            ('p', 'B', 0),
+            ('sum', 'H', 0),
+            ('src', '4s', b'\x00' * 4),
+            ('dst', '4s', b'\x00' * 4)
+        )
+        __bit_fields__ = {
+            '_v_hl': [
+                ('v', 4),   # version, 4 bits
+                ('hl', 4),  # header len, 4 bits
+            ],
+            '_flags_offset': [
+                ('rf', 1),  # reserved bit
+                ('df', 1),  # don't fragment
+                ('mf', 1),  # more fragments
+                ('offset', 13)  # fragment offset, 13 bits
+            ]
+        }
+        __pprint_funcs__ = {
+            'dst': inet_to_str,
+            'src': inet_to_str,
+            'p': get_ip_proto_name
+        }
+
+A lot is going on in the header, before we even get to ``__init__``!
+Here is the breakdown:
+
+1. Note the main ``class IP`` inherits from ``dpkt.Packet``
+
+2. ``__hdr__`` defines a list of fields in the protocol header as 3-item tuples:
+   *(field name, python struct format, default value)*. The fields are arranged
+   in the order they appear on the wire.
+
+   Field names generally follow the definition of the protocol (e.g. the RFC), but
+   there are some rules to naming the fields that affect how ``dpkt`` handles them:
+
+   - a name that doesn't start with an underscore represents a regular public
+     protocol field.
+     *Examples:* ``tos``, ``len``, ``id``
+
+   - a name that starts with an underscore and contains NO more underscores
+     is considered private and gets hidden in ``__repr__`` and ``pprint()`` outputs;
+     this is useful for hiding fields reserved for future use, or fields that
+     should be decoded according to some custom rules.
+     *Example:* ``_reserved``
+
+   - a name that starts with an underscore and DOES contain more underscores
+     is similarly considered private and hidden, but gets processed as a collection
+     of multiple protocol fields, separated by underscore. Each field name may contain
+     up to 1 underscore as well. These fields are only created when the class definition
+     contains matching property definitions, which could be defined explicitly or created
+     automagically via ``__bit_fields__`` (more on this later).
+
+     *Examples:*
+       - ``_foo_bar_m_flag`` will map to fields named ``foo``, ``bar``, ``m_flag``,
+         when the class contains properties with these names.
+
+       - In the IP class the ``_v_hl`` field itself is hidden in the output of
+         ``__repr__`` and ``pprint()``, and is decoded into ``v`` and ``hl`` fields
+         that are displayed instead.
+
+   The second component of the tuple specifies the format of the protocol
+   field, as it corresponds to Python's native ``struct`` module. ``'B'`` means the
+   field will decode to an unsigned byte, ``'H'`` - to an unsigned word, etc.
+   The default byte order is big endian (network order). The endianness can be
+   changed to little endian by specifying ``__byte_order__ = '<'`` in the class
+   definition, or for each individual field (e.g. ``'<H'``).
+
+3. Next, ``__bit_fields__`` is an optional dict that helps decode compound protocol
+   fields, such as ``_v_hl`` or ``_flags_offset`` in the IP class.
+   Each field name (as it appears in ``__hdr__``) maps to a list of tuples, defining
+   the bit fields in the network order (from high to low).
+   Each tuple is *(bit field name, size in bits)*.
+
+   The total sum of bit sizes must match the overall size of the placeholder field.
+   For example, ``_v_hl`` is decoded to 1 byte (``'B'``), or 8 bits;
+   ``v`` (the IP version) occupies the high 4 bits and ``hl`` (IP header length)
+   occupies the lower 4 bits.
+
+   ``_flags_offset`` that is 2 bytes long (``'H'``) is decoded into 3 1-bit flags
+   followed by a 13-bit offset, total of 16 bytes.
+
+   Similarly to the naming rules of ``__hdr__``, a bit field name starting with an
+   underscore is made invisible in the output.
+
+4. Next, ``__pprint_funcs__`` is an optional dict that does not control protocol
+   decoding, but helps with pretty printing of the decoded packet using the ``pprint()``
+   method. Each key in this map is a name of the protocol field, and each value is a
+   callable that will be run with a single argument of the protocol field value.
+
+   For example, it's nice to see the readable IP addresses for ``src`` and ``dst``
+   fields by passing the raw bytes to ``inet_to_str`` function.
+
+
+Standard methods
+****************
+
+Let's look at the standard methods of the Packet class and how they contribute to
+parsing (aka unpacking, aka deserializing) and constructing (aka packing, aka serializing) the packet.
+
+::
+
+    class IP(dpkt.Packet):
+        ...
+        def __init__(self, *args, **kwargs):
+            super(IP, self).__init__(*args, **kwargs)
+            ...
+
+        def __len__(self):
+            return self.__hdr_len__ + len(self.opts) + len(self.data)
+
+        def __bytes__(self):
+            # calculate IP checksum
+            if self.sum == 0:
+                self.sum = dpkt.in_cksum(self.pack_hdr() + bytes(self.opts))
+            ...
+            return self.pack_hdr() + bytes(self.opts) + bytes(self.data)
+
+        def unpack(self, buf):
+            dpkt.Packet.unpack(self, buf)
+            ...
+            self.opts = ...  # add IP options
+            ...
+            self.data = ...  # bytes that remain after unpacking
+
+        def pack_hdr(self):
+            buf = dpkt.Packet.pack_hdr(self)
+            ...
+            return buf
+
+Instantiating the class with a bytes buffer (``ip = dpkt.ip.IP(buf)``) will trigger the unpacking sequence as follows:
+
+1. ``__init__(buf)`` calls ``self.unpack(buf)``
+2. ``Packet.unpack()`` creates protocol fields given in ``__hdr__`` as class attributes, and sets ``self.data`` to the remaining unparsed bytes in the buffer.
+
+Child classes typically extend the ``Packet.unpack()`` method to create additional custom attributes, that are not given in the ``__hdr__`` (such as ``opts`` for IP options below).
+
+Packing is the opposite of unpacking of course; given an instance of a parsed packet, packing  will return serialized packet as a ``bytes`` object (``bytes(ip) => buf``). It goes as follows:
+
+1. Calling ``bytes(obj)`` invokes ``self.__bytes__(obj)``
+2. ``Packet.__bytes()__`` calls ``self.pack_hdr()`` and returns its result with appended ``bytes(self.data)``. The latter recursively triggers serialization of ``self.data``, which could be another packet class, e.g. ``Ethernet(.., data=IP(.., data=TCP(...)))```, so everything gets serialized.
+3. ``Packet.pack_hdr()`` iterates over the protocol fields given in ``__hdr__``, calls ``struct.pack()`` on them and returns the resulting bytes.
+
+Child classes typically extend the ``Packet.__bytes__()`` method to process custom attributes, that are not given in the ``__hdr__``, or to override some values before ``pack_hdr()`` turns them into bytes. See how the IP parser overrides ``__bytes__`` to calculate the IP checksum prior to packing, and insert ``bytes(self.opts)`` between the packed header and data.
+
+__len__
+*******
+
+``__len__()`` returns the size of the serialized packet and is typically invoked when calling ``len(obj)``.
+Note how in the IP class, the method calls other methods to calculate size, then sums the values together, and it **does not** perform serialization. It may be tempting to implement ``__len__`` by serializing the packet into bytes and returning the size of the buffer (``return len(bytes(self))``).
+While working and acceptable in some cases, in general dpkt views this as an anti-pattern that should be avoided.
+
+__repr__ and pprint()
+*********************
+
+These methods are provided by ``dpkt.Packet`` and is typically not overridden in the child class. However they are important to understand when developing protocol parsers. Both ``repr()`` and ``pprint()`` are responsible for the output, and both produce valid interpretable Python, but there are some differences:
+
+1. ``__repr__`` returns a short one-liner printable string, while ``pprint()`` actually prints and returns nothing
+2. ``__repr__`` does not include protocol fields if their value is default, i.e. it will only display a field when it differs from the default.
+   *Example:* in IPv4 the version always equals 4 so normally field ``v`` is not included.
+3. ``pprint()`` is verbose; its output is one field per line, indented, outdented and commented, and contrary to ``__repr__`` it includes all protocol fields, even when their value IS default.
+4. ``__repr__`` does not use the ``__pprint_funcs__`` and returns raw values. See below how ``src`` and ``dst`` IP addresses get human readable interpretation with ``pprint()``, but not with ``__repr__``.
+
+::
+
+    # repr()
+    >>> ip
+    IP(len=34, p=17, sum=29376, src=b'\x01\x02\x03\x04', dst=b'\x01\x02\x03\x04', opts=b'', data=UDP(sport=111, dport=222, ulen=14, sum=48949, data=b'foobar'))
+
+    # IP version field is default and is not returned by repr()
+    >>> ip.v
+    4
+
+    >>> ip.pprint()
+    IP(
+      v=4,
+      hl=5,
+      tos=0,
+      len=34,
+      id=0,
+      rf=0,
+      df=0,
+      mf=0,
+      offset=0,
+      ttl=64,
+      p=17,  # UDP
+      sum=29376,
+      src=b'\x01\x02\x03\x04',  # 1.2.3.4
+      dst=b'\x01\x02\x03\x04',  # 1.2.3.4
+      opts=b'',
+      data=UDP(
+        sport=111,
+        dport=222,
+        ulen=14,
+        sum=48949,
+        data=b'foobar'
+      )  # UDP
+    )  # IP

--- a/docs/creating_parsers.rst
+++ b/docs/creating_parsers.rst
@@ -43,7 +43,7 @@ Let's look at the IPv4 parser, defined in ``dpkt/ip.py``, as an example.
             'p': get_ip_proto_name
         }
 
-A lot is going on in the header, before we even get to ``__init__``!
+A lot is going on in the header, before we even got to ``__init__``!
 Here is the breakdown:
 
 1. Note the main ``class IP`` inherits from ``dpkt.Packet``
@@ -52,8 +52,8 @@ Here is the breakdown:
    *(field name, python struct format, default value)*. The fields are arranged
    in the order they appear on the wire.
 
-   Field names generally follow the definition of the protocol (e.g. the RFC), but
-   there are some rules to naming the fields that affect how ``dpkt`` handles them:
+   Field names generally follow the protocol definitions (e.g. RFC), but there are 
+   some rules to naming the fields that affect ``dpkt`` processing:
 
    - a name that doesn't start with an underscore represents a regular public
      protocol field.
@@ -118,15 +118,15 @@ Here is the breakdown:
    method. Each key in this map is a name of the protocol field, and each value is a
    callable that will be run with a single argument of the protocol field value.
 
-   For example, it's nice to see the readable IP addresses for ``src`` and ``dst``
+   For example, it's nice to see human readable IP addresses for ``src`` and ``dst``
    fields by passing the raw bytes to ``inet_to_str`` function.
 
 
 Standard methods
 ****************
 
-Let's look at the standard methods of the Packet class and how they contribute to
-parsing (aka unpacking, aka deserializing) and constructing (aka packing, aka serializing) the packet.
+Let's look at the standard methods of the ``Packet`` class and how they contribute to
+parsing (aka unpacking or deserializing) and constructing (aka packing or serializing) the packet.
 
 ::
 
@@ -177,13 +177,14 @@ __len__
 *******
 
 ``__len__()`` returns the size of the serialized packet and is typically invoked when calling ``len(obj)``.
-Note how in the IP class, the method calls other methods to calculate size, then sums the values together, and it **does not** perform serialization. It may be tempting to implement ``__len__`` by serializing the packet into bytes and returning the size of the buffer (``return len(bytes(self))``).
-While working and acceptable in some cases, in general dpkt views this as an anti-pattern that should be avoided.
+Note how in the IP class, this method calls other functions to calculate size, then sums the lengths together, and it **does not** perform serialization. 
+It may be tempting to implement ``__len__`` by serializing the packet into bytes and returning the size of the resulting buffer (``return len(bytes(self))``).
+While this works and is acceptable in some cases, dpkt views this as an anti-pattern that should be avoided.
 
 __repr__ and pprint()
 *********************
 
-These methods are provided by ``dpkt.Packet`` and is typically not overridden in the child class. However they are important to understand when developing protocol parsers. Both ``repr()`` and ``pprint()`` are responsible for the output, and both produce valid interpretable Python, but there are some differences:
+These methods are provided by ``dpkt.Packet`` and are typically not overridden in the child class. However they are important to understand when developing protocol parsers. Both ``repr()`` and ``pprint()`` are responsible for the output, and both produce valid interpretable Python, but there are some differences:
 
 1. ``__repr__`` returns a short one-liner printable string, while ``pprint()`` actually prints and returns nothing
 2. ``__repr__`` does not include protocol fields if their value is default, i.e. it will only display a field when it differs from the default.

--- a/docs/creating_parsers.rst
+++ b/docs/creating_parsers.rst
@@ -90,8 +90,8 @@ Here is the breakdown:
 
 3. Next, ``__bit_fields__`` is an optional dict that helps decode compound protocol
    fields, such as ``_v_hl`` or ``_flags_offset`` in the IP class.
-   Each field name (as it appears in ``__hdr__``) maps to a list of tuples, defining
-   the bit fields in the network order (from high to low).
+   Each field name (as it appears in ``__hdr__``) maps to a list (technically a tuple)
+   of tuples, defining the bit fields in the network order (from high to low).
    Each tuple is *(bit field name, size in bits)*.
 
    The total sum of bit sizes must match the overall size of the placeholder field.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,7 @@ About dpkt
     changelog
     plans
     contributing
+    creating_parsers
     license
 
 Administration

--- a/dpkt/aoe.py
+++ b/dpkt/aoe.py
@@ -20,30 +20,20 @@ class AOE(dpkt.Packet):
     """
 
     __hdr__ = (
-        ('ver_fl', 'B', 0x10),
+        ('_ver_fl', 'B', 0x10),
         ('err', 'B', 0),
         ('maj', 'H', 0),
         ('min', 'B', 0),
         ('cmd', 'B', 0),
         ('tag', 'I', 0),
     )
+    __bit_fields__ = {
+        '_ver_fl': [
+            ('ver', 4),
+            ('fl', 4)
+        ]
+    }
     _cmdsw = {}
-
-    @property
-    def ver(self):
-        return self.ver_fl >> 4
-
-    @ver.setter
-    def ver(self, ver):
-        self.ver_fl = (ver << 4) | (self.ver_fl & 0xf)
-
-    @property
-    def fl(self):
-        return self.ver_fl & 0xf
-
-    @fl.setter
-    def fl(self, fl):
-        self.ver_fl = (self.ver_fl & 0xf0) | fl
 
     @classmethod
     def set_cmd(cls, cmd, pktclass):
@@ -90,13 +80,13 @@ def _mod_init():
 def test_creation():
     aoe = AOE()
     # hdr fields
-    assert aoe.ver_fl == 0x10
+    assert aoe._ver_fl == 0x10
     assert aoe.err == 0
     assert aoe.maj == 0
     assert aoe.min == 0
     assert aoe.cmd == 0
     assert aoe.tag == 0
-    assert bytes(aoe) == b'\x10' + b'\x00'*9
+    assert bytes(aoe) == b'\x10' + b'\x00' * 9
 
 
 def test_properties():
@@ -108,11 +98,11 @@ def test_properties():
     # property setters
     aoe.ver = 2
     assert aoe.ver == 2
-    assert aoe.ver_fl == 0x20
+    assert aoe._ver_fl == 0x20
 
     aoe.fl = 12
     assert aoe.fl == 12
-    assert aoe.ver_fl == 0x2C
+    assert aoe._ver_fl == 0x2C
 
 
 def test_unpack():

--- a/dpkt/aoe.py
+++ b/dpkt/aoe.py
@@ -28,10 +28,10 @@ class AOE(dpkt.Packet):
         ('tag', 'I', 0),
     )
     __bit_fields__ = {
-        '_ver_fl': [
+        '_ver_fl': (
             ('ver', 4),
-            ('fl', 4)
-        ]
+            ('fl', 4),
+        )
     }
     _cmdsw = {}
 

--- a/dpkt/compat.py
+++ b/dpkt/compat.py
@@ -51,14 +51,3 @@ def isstr(s):
     """True if 's' is an instance of basestring in py2, or of str in py3"""
     bs = getattr(__builtins__, 'basestring', str)
     return isinstance(s, bs)
-
-
-# DeprecationWarning is ignored in Python 2 starting with 2.7
-import warnings
-if (2, 7) <= sys.version_info < (3, ):
-    def deprecation_warning(*args):
-        warnings.warn(*args)
-
-else:  # py3
-    def deprecation_warning(*args):
-        warnings.warn(*args, category=DeprecationWarning)

--- a/dpkt/compat.py
+++ b/dpkt/compat.py
@@ -51,3 +51,14 @@ def isstr(s):
     """True if 's' is an instance of basestring in py2, or of str in py3"""
     bs = getattr(__builtins__, 'basestring', str)
     return isinstance(s, bs)
+
+
+# DeprecationWarning is ignored in Python 2 starting with 2.7
+import warnings
+if (2, 7) <= sys.version_info < (3, ):
+    def deprecation_warning(*args):
+        warnings.warn(*args)
+
+else:  # py3
+    def deprecation_warning(*args):
+        warnings.warn(*args, category=DeprecationWarning)

--- a/dpkt/dpkt.py
+++ b/dpkt/dpkt.py
@@ -55,8 +55,15 @@ class _MetaPacket(type):
                             setattr(self, ph_name, val)
                         return setter_func
 
-                    clsdict[bf_name] = property(make_getter(), make_setter())
-                    # TODO: we could add property delete to set the field back to its default value
+                    # delete property to set the bit field back to its default value
+                    def make_delete(ph_name=ph_name, mask=mask, mask_inv=mask_inv):
+                        def delete_func(self):
+                            ph_val = getattr(self, ph_name)
+                            ph_val_new = (self.__hdr_defaults__[ph_name] & mask) | (ph_val & mask_inv)
+                            setattr(self, ph_name, ph_val_new)
+                        return delete_func
+
+                    clsdict[bf_name] = property(make_getter(), make_setter(), make_delete())
 
                 bits_used += bf_size
                 assert bits_total - bits_used >= 0

--- a/dpkt/dpkt.py
+++ b/dpkt/dpkt.py
@@ -33,7 +33,6 @@ class PackError(Error):
 class _MetaPacket(type):
     def __new__(cls, clsname, clsbases, clsdict):
         t = type.__new__(cls, clsname, clsbases, clsdict)
-
         st = getattr(t, '__hdr__', None)
         if st is not None:
             # XXX - __slots__ only created in __new__()
@@ -453,10 +452,10 @@ def test_bit_fields_overflow():
             ('_a_b', 'B', 0),
         )
         __bit_fields__ = {
-            '_a_b': [
+            '_a_b': (
                 ('a', 2),
-                ('b', 6)
-            ]
+                ('b', 6),
+            )
         }
 
     foo = Foo()
@@ -497,10 +496,10 @@ def test_repr():
         __hdr__ = (('_a_b', 'B', 0),)
 
         __bit_fields__ = {
-            '_a_b': [
+            '_a_b': (
                 ('a', 4),
                 ('b', 4),
-            ],
+            ),
         }
 
     # default values so no output

--- a/dpkt/dpkt.py
+++ b/dpkt/dpkt.py
@@ -57,7 +57,9 @@ class _MetaPacket(type):
                     bits_used = 0
 
                     # make sure the sum of bits matches the overall size of the placeholder field
-                    assert bits_total == struct.calcsize(ph_struct) * 8
+                    assert bits_total == struct.calcsize(ph_struct) * 8, \
+                        "the overall count of bits in [%s] as declared in __bit_fields__ " \
+                        "does not match its struct size in __hdr__" % ph_name
 
                     for (bf_name, bf_size) in field_defs:
                         if bf_name.startswith('_'):  # do not create properties for _private fields
@@ -192,7 +194,8 @@ class Packet(_MetaPacket("Temp", (object,), {})):
                             l_.append(prop_name)
 
                 # (2) split by underscore into 1- and 2-component names and look for properties with such names;
-                # Example: _foo_bar -> look for properties named "foo", "bar" and "foo_bar"
+                # Example: _foo_bar_baz -> look for properties named "foo", "bar", "baz", "foo_bar" and "bar_baz"
+                # (but not "foo_bar_baz" since it contains more than one underscore)
                 else:
                     fns = field_name[1:].split('_')
                     for prop_name in chain(fns, ('_'.join(x) for x in zip(fns, fns[1:]))):

--- a/dpkt/dpkt.py
+++ b/dpkt/dpkt.py
@@ -102,8 +102,6 @@ class _MetaPacket(type):
 
                         setattr(t, bf_name, property(make_getter(), make_setter(), make_delete()))
 
-                    assert bits_used == bits_total
-
         # optional map of functions for pretty printing
         # {field_name: callable(field_value) -> str, ..}
         # define as needed in the child protocol classes

--- a/dpkt/dpkt.py
+++ b/dpkt/dpkt.py
@@ -444,6 +444,26 @@ def test_pack_hdr_overflow():
         bytes(foo)
 
 
+def test_bit_fields_overflow():
+    """Try to fit too much data into too few bits"""
+    import pytest
+
+    class Foo(Packet):
+        __hdr__ = (
+            ('_a_b', 'B', 0),
+        )
+        __bit_fields__ = {
+            '_a_b': [
+                ('a', 2),
+                ('b', 6)
+            ]
+        }
+
+    foo = Foo()
+    with pytest.raises(ValueError):
+        foo.a = 5
+
+
 def test_pack_hdr_tuple():
     """Test the unpacking of a tuple for a single format string"""
     class Foo(Packet):

--- a/dpkt/ethernet.py
+++ b/dpkt/ethernet.py
@@ -330,22 +330,14 @@ class MPLSlabel(dpkt.Packet):
     )
     # field names are according to RFC3032
 
-    def unpack(self, buf):
-        dpkt.Packet.unpack(self, buf)
-        self.val = (self._val_exp_s_ttl & 0xfffff000) >> 12  # label value, 20 bits
-        self.exp = (self._val_exp_s_ttl & 0x00000e00) >> 9   # experimental use, 3 bits
-        self.s = (self._val_exp_s_ttl & 0x00000100) >> 8     # bottom of stack flag, 1 bit
-        self.ttl = self._val_exp_s_ttl & 0x000000ff          # time to live, 8 bits
-        self.data = b''
-
-    def pack_hdr(self):
-        self._val_exp_s_ttl = (
-            ((self.val & 0xfffff) << 12) |
-            ((self.exp & 7) << 9) |
-            ((self.s & 1) << 8) |
-            ((self.ttl & 0xff))
-        )
-        return dpkt.Packet.pack_hdr(self)
+    __bit_fields__ = {
+        '_val_exp_s_ttl': [
+            ('val', 20),  # label value, 20 bits
+            ('exp', 3),   # experimental use, 3 bits
+            ('s', 1),     # bottom of stack flag, 1 bit
+            ('ttl', 8),   # time to live, 8 bits
+        ]
+    }
 
     def as_tuple(self):  # backward-compatible representation
         return (self.val, self.exp, self.ttl)
@@ -358,21 +350,13 @@ class VLANtag8021Q(dpkt.Packet):
         ('_pri_cfi_id', 'H', 0),
         ('type', 'H', ETH_TYPE_IP)
     )
-
-    def unpack(self, buf):
-        dpkt.Packet.unpack(self, buf)
-        self.pri = (self._pri_cfi_id & 0xe000) >> 13   # priority, 3 bits
-        self.cfi = (self._pri_cfi_id & 0x1000) >> 12   # canonical format indicator, 1 bit
-        self.id = self._pri_cfi_id & 0x0fff           # VLAN id, 12 bits
-        self.data = b''
-
-    def pack_hdr(self):
-        self._pri_cfi_id = (
-            ((self.pri & 7) << 13) |
-            ((self.cfi & 1) << 12) |
-            ((self.id & 0xfff))
-        )
-        return dpkt.Packet.pack_hdr(self)
+    __bit_fields__ = {
+        '_pri_cfi_id': [
+            ('pri', 3),  # priority, 3 bits
+            ('cfi', 1),  # canonical format indicator, 1 bit
+            ('id', 12),  # VLAN id, 12 bits
+        ]
+    }
 
     def as_tuple(self):
         return (self.id, self.pri, self.cfi)
@@ -392,19 +376,16 @@ class VLANtagISL(dpkt.Packet):
         ('indx', 'H', 0),
         ('res', 'H', 0)
     )
-
-    def unpack(self, buf):
-        dpkt.Packet.unpack(self, buf)
-        self.type = (self._type_pri & 0xf0) >> 4  # encapsulation type, 4 bits; 0 means Ethernet
-        self.pri = self._type_pri & 0x03  # user defined bits, 2 bits are used; means priority
-        self.id = self._id_bpdu >> 1  # VLAN id
-        self.bpdu = self._id_bpdu & 1
-        self.data = b''
-
-    def pack_hdr(self):
-        self._type_pri = ((self.type & 0xf) << 4) | (self.pri & 0x3)
-        self._id_bpdu = ((self.id & 0x7fff) << 1) | (self.bpdu & 1)
-        return dpkt.Packet.pack_hdr(self)
+    __bit_fields__ = {
+        '_type_pri': [
+            ('type', 4),  # encapsulation type, 4 bits; 0 means Ethernet
+            ('pri', 4)    # user defined bits, 2 lo bits are used; means priority
+        ],
+        '_id_bpdu': [
+            ('id', 15),   # vlan id, 15 bits
+            ('bpdu', 1)   # bridge protocol data unit indicator
+        ]
+    }
 
 
 # Unit tests

--- a/dpkt/ethernet.py
+++ b/dpkt/ethernet.py
@@ -330,12 +330,12 @@ class MPLSlabel(dpkt.Packet):
     )
     # field names are according to RFC3032
     __bit_fields__ = {
-        '_val_exp_s_ttl': [
+        '_val_exp_s_ttl': (
             ('val', 20),  # label value, 20 bits
             ('exp', 3),   # experimental use, 3 bits
             ('s', 1),     # bottom of stack flag, 1 bit
             ('ttl', 8),   # time to live, 8 bits
-        ]
+        )
     }
 
     def unpack(self, buf):
@@ -354,11 +354,11 @@ class VLANtag8021Q(dpkt.Packet):
         ('type', 'H', ETH_TYPE_IP)
     )
     __bit_fields__ = {
-        '_pri_cfi_id': [
+        '_pri_cfi_id': (
             ('pri', 3),  # priority, 3 bits
             ('cfi', 1),  # canonical format indicator, 1 bit
             ('id', 12),  # VLAN id, 12 bits
-        ]
+        )
     }
 
     def unpack(self, buf):
@@ -384,14 +384,14 @@ class VLANtagISL(dpkt.Packet):
         ('res', 'H', 0)
     )
     __bit_fields__ = {
-        '_type_pri': [
+        '_type_pri': (
             ('type', 4),  # encapsulation type, 4 bits; 0 means Ethernet
-            ('pri', 4)    # user defined bits, 2 lo bits are used; means priority
-        ],
-        '_id_bpdu': [
+            ('pri', 4),   # user defined bits, 2 lo bits are used; means priority
+        ),
+        '_id_bpdu': (
             ('id', 15),   # vlan id, 15 bits
-            ('bpdu', 1)   # bridge protocol data unit indicator
-        ]
+            ('bpdu', 1),  # bridge protocol data unit indicator
+        )
     }
 
     def unpack(self, buf):

--- a/dpkt/ethernet.py
+++ b/dpkt/ethernet.py
@@ -338,6 +338,9 @@ class MPLSlabel(dpkt.Packet):
             ('ttl', 8),   # time to live, 8 bits
         ]
     }
+    def __init__(self, *args, **kwargs):
+        super(MPLSlabel, self).__init__(*args, **kwargs)
+        self.data = b''
 
     def as_tuple(self):  # backward-compatible representation
         return (self.val, self.exp, self.ttl)

--- a/dpkt/ethernet.py
+++ b/dpkt/ethernet.py
@@ -329,7 +329,6 @@ class MPLSlabel(dpkt.Packet):
         ('_val_exp_s_ttl', 'I', 0),
     )
     # field names are according to RFC3032
-
     __bit_fields__ = {
         '_val_exp_s_ttl': [
             ('val', 20),  # label value, 20 bits
@@ -338,8 +337,9 @@ class MPLSlabel(dpkt.Packet):
             ('ttl', 8),   # time to live, 8 bits
         ]
     }
-    def __init__(self, *args, **kwargs):
-        super(MPLSlabel, self).__init__(*args, **kwargs)
+
+    def unpack(self, buf):
+        dpkt.Packet.unpack(self, buf)
         self.data = b''
 
     def as_tuple(self):  # backward-compatible representation
@@ -360,6 +360,10 @@ class VLANtag8021Q(dpkt.Packet):
             ('id', 12),  # VLAN id, 12 bits
         ]
     }
+
+    def unpack(self, buf):
+        dpkt.Packet.unpack(self, buf)
+        self.data = b''
 
     def as_tuple(self):
         return (self.id, self.pri, self.cfi)
@@ -389,6 +393,10 @@ class VLANtagISL(dpkt.Packet):
             ('bpdu', 1)   # bridge protocol data unit indicator
         ]
     }
+
+    def unpack(self, buf):
+        dpkt.Packet.unpack(self, buf)
+        self.data = b''
 
 
 # Unit tests

--- a/dpkt/ip.py
+++ b/dpkt/ip.py
@@ -30,7 +30,7 @@ class IP(dpkt.Packet):
         ('tos', 'B', 0),
         ('len', 'H', 20),
         ('id', 'H', 0),
-        ('_off', 'H', 0),  # XXX - ip.off is deprecated and renamed to ip._off
+        ('_flags_offset', 'H', 0),  # XXX - previously ip.off
         ('ttl', 'B', 64),
         ('p', 'B', 0),
         ('sum', 'H', 0),
@@ -42,7 +42,7 @@ class IP(dpkt.Packet):
             ('v', 4),   # version, 4 bits
             ('hl', 4),  # header len, 4 bits
         ],
-        '_off': [
+        '_flags_offset': [
             ('rf', 1),  # reserved bit
             ('df', 1),  # don't fragment
             ('mf', 1),  # more fragments
@@ -60,8 +60,6 @@ class IP(dpkt.Packet):
 
     def __init__(self, *args, **kwargs):
         super(IP, self).__init__(*args, **kwargs)
-
-        self.off = self._off  # XXX - compatibility; to be deprecated
 
         # If IP packet is not initialized by string and the len field has
         # been rewritten.
@@ -118,6 +116,15 @@ class IP(dpkt.Packet):
     @classmethod
     def get_proto(cls, p):
         return cls._protosw[p]
+
+    # XXX - compatibility; to be deprecated
+    @property
+    def off(self):
+        return self._flags_offset
+
+    @off.setter
+    def off(self, val):
+        self.offset = val
 
 
 # IP Headers

--- a/dpkt/ip.py
+++ b/dpkt/ip.py
@@ -38,16 +38,16 @@ class IP(dpkt.Packet):
         ('dst', '4s', b'\x00' * 4)
     )
     __bit_fields__ = {
-        '_v_hl': [
+        '_v_hl': (
             ('v', 4),   # version, 4 bits
             ('hl', 4),  # header len, 4 bits
-        ],
-        '_flags_offset': [
+        ),
+        '_flags_offset': (
             ('rf', 1),  # reserved bit
             ('df', 1),  # don't fragment
             ('mf', 1),  # more fragments
-            ('offset', 13)  # fragment offset, 13 bits
-        ]
+            ('offset', 13),  # fragment offset, 13 bits
+        )
     }
     __pprint_funcs__ = {
         'dst': inet_to_str,

--- a/dpkt/ip.py
+++ b/dpkt/ip.py
@@ -428,10 +428,15 @@ def test_property_setters():
     assert ip.v == 4
     ip.v = 6
     assert ip.v == 6
+    # test property delete
+    del ip.v
+    assert ip.v == 4  # back to default
 
     assert ip.hl == 5
     ip.hl = 7
     assert ip.hl == 7
+    del ip.hl
+    assert ip.hl == 5
 
 
 def test_default_udp_checksum():

--- a/dpkt/ip.py
+++ b/dpkt/ip.py
@@ -445,6 +445,10 @@ def test_property_setters():
     del ip.hl
     assert ip.hl == 5
 
+    # coverage
+    ip.off = 10
+    assert ip.off == 10
+
 
 def test_default_udp_checksum():
     from dpkt.udp import UDP

--- a/dpkt/ip.py
+++ b/dpkt/ip.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 from . import dpkt
-from .compat import iteritems
+from .compat import iteritems, deprecation_warning
 from .utils import inet_to_str
 
 _ip_proto_names = {}  # {1: 'ICMP', 6: 'TCP', 17: 'UDP', etc.}
@@ -120,10 +120,12 @@ class IP(dpkt.Packet):
     # XXX - compatibility; to be deprecated
     @property
     def off(self):
+        deprecation_warning("IP.off is deprecated")
         return self._flags_offset
 
     @off.setter
     def off(self, val):
+        deprecation_warning("IP.off is deprecated")
         self.offset = val
 
 

--- a/dpkt/ip.py
+++ b/dpkt/ip.py
@@ -73,7 +73,7 @@ class IP(dpkt.Packet):
         self.len = self.__len__()
         if self.sum == 0:
             self.sum = dpkt.in_cksum(self.pack_hdr() + bytes(self.opts))
-            if (self.p == 6 or self.p == 17) and (self._off & (IP_MF | IP_OFFMASK)) == 0 and \
+            if (self.p == 6 or self.p == 17) and (self._flags_offset & (IP_MF | IP_OFFMASK)) == 0 and \
                     isinstance(self.data, dpkt.Packet) and self.data.sum == 0:
                 # Set zeroed TCP and UDP checksums for non-fragments.
                 p = bytes(self.data)

--- a/dpkt/ip.py
+++ b/dpkt/ip.py
@@ -30,79 +30,43 @@ class IP(dpkt.Packet):
         ('tos', 'B', 0),
         ('len', 'H', 20),
         ('id', 'H', 0),
-        ('off', 'H', 0),
+        ('_off', 'H', 0),  # XXX - ip.off is deprecated and renamed to ip._off
         ('ttl', 'B', 64),
         ('p', 'B', 0),
         ('sum', 'H', 0),
         ('src', '4s', b'\x00' * 4),
         ('dst', '4s', b'\x00' * 4)
     )
-
+    __bit_fields__ = {
+        '_v_hl': [
+            ('v', 4),   # version, 4 bits
+            ('hl', 4),  # header len, 4 bits
+        ],
+        '_off': [
+            ('rf', 1),  # reserved bit
+            ('df', 1),  # don't fragment
+            ('mf', 1),  # more fragments
+            ('offset', 13)  # fragment offset, 13 bits
+        ]
+    }
     __pprint_funcs__ = {
         'dst': inet_to_str,
         'src': inet_to_str,
         'sum': hex,  # display checksum in hex
         'p': get_ip_proto_name
     }
-
     _protosw = {}
     opts = b''
 
     def __init__(self, *args, **kwargs):
         super(IP, self).__init__(*args, **kwargs)
 
+        self.off = self._off  # XXX - compatibility; to be deprecated
+
         # If IP packet is not initialized by string and the len field has
         # been rewritten.
         if not args and 'len' not in kwargs:
             self.len = self.__len__()
-
-    @property
-    def v(self):
-        return self._v_hl >> 4
-
-    @v.setter
-    def v(self, v):
-        self._v_hl = (v << 4) | (self._v_hl & 0xf)
-
-    @property
-    def hl(self):
-        return self._v_hl & 0xf
-
-    @hl.setter
-    def hl(self, hl):
-        self._v_hl = (self._v_hl & 0xf0) | hl
-
-    @property
-    def rf(self):
-        return (self.off >> 15) & 0x1
-
-    @rf.setter
-    def rf(self, rf):
-        self.off = (self.off & ~IP_RF) | (rf << 15)
-
-    @property
-    def df(self):
-        return (self.off >> 14) & 0x1
-
-    @df.setter
-    def df(self, df):
-        self.off = (self.off & ~IP_DF) | (df << 14)
-
-    @property
-    def mf(self):
-        return (self.off >> 13) & 0x1
-
-    @mf.setter
-    def mf(self, mf):
-        self.off = (self.off & ~IP_MF) | (mf << 13)
-
-    @property
-    def offset(self):
-        return (self.off & IP_OFFMASK) << 3
-
-    @offset.setter
-    def offset(self, offset):
-        self.off = (self.off & ~IP_OFFMASK) | (offset >> 3)
 
     def __len__(self):
         return self.__hdr_len__ + len(self.opts) + len(self.data)
@@ -111,7 +75,7 @@ class IP(dpkt.Packet):
         self.len = self.__len__()
         if self.sum == 0:
             self.sum = dpkt.in_cksum(self.pack_hdr() + bytes(self.opts))
-            if (self.p == 6 or self.p == 17) and (self.off & (IP_MF | IP_OFFMASK)) == 0 and \
+            if (self.p == 6 or self.p == 17) and (self._off & (IP_MF | IP_OFFMASK)) == 0 and \
                     isinstance(self.data, dpkt.Packet) and self.data.sum == 0:
                 # Set zeroed TCP and UDP checksums for non-fragments.
                 p = bytes(self.data)
@@ -122,9 +86,9 @@ class IP(dpkt.Packet):
 
                 # RFC 768 (Fields):
                 # If the computed checksum is zero, it is transmitted as all
-                # ones (the equivalent in one's complement arithmetic). An all
-                # zero transmitted checksum value means that the transmitter
-                # generated no checksum (for debugging or for higher level
+                # ones (the equivalent in one's complement arithmetic). An all
+                # zero transmitted checksum value means that the transmitter
+                # generated no checksum (for debugging or for higher level
                 # protocols that don't care).
                 if self.p == 17 and self.data.sum == 0:
                     self.data.sum = 0xffff

--- a/dpkt/ip.py
+++ b/dpkt/ip.py
@@ -5,8 +5,8 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 from . import dpkt
-from .compat import iteritems, deprecation_warning
-from .utils import inet_to_str
+from .compat import iteritems
+from .utils import inet_to_str, deprecation_warning
 
 _ip_proto_names = {}  # {1: 'ICMP', 6: 'TCP', 17: 'UDP', etc.}
 

--- a/dpkt/ip6.py
+++ b/dpkt/ip6.py
@@ -534,6 +534,14 @@ def test_ip6_properties():
     ip6.flow = 4
     assert ip6.flow == 4
 
+    # property delete
+    del ip6.v
+    del ip6.fc
+    del ip6.flow
+    assert ip6.v == 6
+    assert ip6.fc == 0
+    assert ip6.flow == 0
+
 
 def test_proto_accessors():
     class Proto:

--- a/dpkt/ip6.py
+++ b/dpkt/ip6.py
@@ -36,11 +36,11 @@ class IP6(dpkt.Packet):
         ('dst', '16s', b'')
     )
     __bit_fields__ = {
-        '_v_fc_flow': [
+        '_v_fc_flow': (
             ('v', 4),      # version, 4 hi bits
             ('fc', 8),     # traffic class, 8 bits
             ('flow', 20),  # flow label, 20 lo bits
-        ]
+        )
     }
     __pprint_funcs__ = {
         'src': inet_to_str,
@@ -209,10 +209,10 @@ class IP6RoutingHeader(IP6ExtensionHeader):
         ('_rsvd_sl_bits', 'I', 0)
     )
     __bit_fields__ = {
-        '_rsvd_sl_bits': [
-            ('_rsvd', 8),    # reserved (1 byte)
-            ('sl_bits', 24)  # strict/loose bitmap for addresses
-        ]
+        '_rsvd_sl_bits': (
+            ('_rsvd', 8),     # reserved (1 byte)
+            ('sl_bits', 24),  # strict/loose bitmap for addresses
+        )
     }
 
     def unpack(self, buf):
@@ -241,11 +241,11 @@ class IP6FragmentHeader(IP6ExtensionHeader):
         ('id', 'I', 0)  # fragments id
     )
     __bit_fields__ = {
-        '_frag_off_resv_m': [
+        '_frag_off_resv_m': (
             ('frag_off', 13),  # frag offset, 13 bits
             ('_resv', 2),      # reserved zero (2 bits)
             ('m_flag', 1),     # more frags flag
-        ]
+        )
     }
 
     def unpack(self, buf):

--- a/dpkt/ip6.py
+++ b/dpkt/ip6.py
@@ -344,7 +344,7 @@ def test_ip6_fragment_header():
     assert fh.m_flag == 1
 
     # test packing
-    fh.frag_off_resv_m = 0
+    fh._frag_off_resv_m = 0
     fh.frag_off = 8191
     fh.m_flag = 1
     assert bytes(fh) == s

--- a/dpkt/ntp.py
+++ b/dpkt/ntp.py
@@ -47,30 +47,13 @@ class NTP(dpkt.Packet):
         ('receive_time', '8s', 0),
         ('transmit_time', '8s', 0)
     )
-
-    @property
-    def v(self):
-        return (self.flags >> 3) & 0x7
-
-    @v.setter
-    def v(self, v):
-        self.flags = (self.flags & ~0x38) | ((v & 0x7) << 3)
-
-    @property
-    def li(self):
-        return (self.flags >> 6) & 0x3
-
-    @li.setter
-    def li(self, li):
-        self.flags = (self.flags & ~0xc0) | ((li & 0x3) << 6)
-
-    @property
-    def mode(self):
-        return self.flags & 0x7
-
-    @mode.setter
-    def mode(self, mode):
-        self.flags = (self.flags & ~0x7) | (mode & 0x7)
+    __bit_fields__ = {
+        'flags': [
+            ('li', 2),   # leap indicator, 2 hi bits
+            ('v', 3),    # version, 3 bits
+            ('mode', 3)  # mode, 3 lo bits
+        ]
+    }
 
 
 __s = (b'\x24\x02\x04\xef\x00\x00\x00\x84\x00\x00\x33\x27\xc1\x02\x04\x02\xc8\x90\xec\x11\x22\xae'

--- a/dpkt/ntp.py
+++ b/dpkt/ntp.py
@@ -48,11 +48,11 @@ class NTP(dpkt.Packet):
         ('transmit_time', '8s', 0)
     )
     __bit_fields__ = {
-        'flags': [
-            ('li', 2),   # leap indicator, 2 hi bits
-            ('v', 3),    # version, 3 bits
-            ('mode', 3)  # mode, 3 lo bits
-        ]
+        'flags': (
+            ('li', 2),    # leap indicator, 2 hi bits
+            ('v', 3),     # version, 3 bits
+            ('mode', 3),  # mode, 3 lo bits
+        )
     }
 
 

--- a/dpkt/pim.py
+++ b/dpkt/pim.py
@@ -18,25 +18,15 @@ class PIM(dpkt.Packet):
 
     __hdr__ = (
         ('_v_type', 'B', 0x20),
-        ('rsvd', 'B', 0),
+        ('_rsvd', 'B', 0),
         ('sum', 'H', 0)
     )
-
-    @property
-    def v(self):
-        return self._v_type >> 4
-
-    @v.setter
-    def v(self, v):
-        self._v_type = (v << 4) | (self._v_type & 0xf)
-
-    @property
-    def type(self):
-        return self._v_type & 0xf
-
-    @type.setter
-    def type(self, type):
-        self._v_type = (self._v_type & 0xf0) | type
+    __bit_fields__ = {
+        '_v_type': [
+            ('v', 4),
+            ('type', 4)
+        ]
+    }
 
     def __bytes__(self):
         if not self.sum:

--- a/dpkt/pim.py
+++ b/dpkt/pim.py
@@ -22,10 +22,10 @@ class PIM(dpkt.Packet):
         ('sum', 'H', 0)
     )
     __bit_fields__ = {
-        '_v_type': [
+        '_v_type': (
             ('v', 4),
-            ('type', 4)
-        ]
+            ('type', 4),
+        )
     }
 
     def __bytes__(self):

--- a/dpkt/pppoe.py
+++ b/dpkt/pppoe.py
@@ -34,22 +34,12 @@ class PPPoE(dpkt.Packet):
         ('session', 'H', 0),
         ('len', 'H', 0)  # payload length
     )
-
-    @property
-    def v(self):
-        return self._v_type >> 4
-
-    @v.setter
-    def v(self, v):
-        self._v_type = (v << 4) | (self._v_type & 0xf)
-
-    @property
-    def type(self):
-        return self._v_type & 0xf
-
-    @type.setter
-    def type(self, t):
-        self._v_type = (self._v_type & 0xf0) | t
+    __bit_fields__ = {
+        '_v_type': [
+            ('v', 4),
+            ('type', 4)
+        ]
+    }
 
     def unpack(self, buf):
         dpkt.Packet.unpack(self, buf)

--- a/dpkt/pppoe.py
+++ b/dpkt/pppoe.py
@@ -35,10 +35,10 @@ class PPPoE(dpkt.Packet):
         ('len', 'H', 0)  # payload length
     )
     __bit_fields__ = {
-        '_v_type': [
+        '_v_type': (
             ('v', 4),
-            ('type', 4)
-        ]
+            ('type', 4),
+        )
     }
 
     def unpack(self, buf):

--- a/dpkt/ssl.py
+++ b/dpkt/ssl.py
@@ -9,7 +9,8 @@ import binascii
 
 from . import dpkt
 from . import ssl_ciphersuites
-from .compat import compat_ord, deprecation_warning
+from .compat import compat_ord
+from .utils import deprecation_warning
 
 #
 # Note from April 2011: cde...@gmail.com added code that parses SSL3/TLS messages more in depth.
@@ -658,7 +659,7 @@ class TestClientHello(object):
     def test_client_random_correct(self):
         assert (self.p.data.random == _hexdecode(b'5008220ce5e0e78b6891afe204498c9363feffbe03235a2d9e05b7d990eb708d'))
 
-    def test_cipher_suite(self):
+    def test_ciphersuites(self):
         assert (tuple([c.code for c in self.p.data.ciphersuites]) == struct.unpack('!{0}H'.format(
             len(self.p.data.ciphersuites)), _hexdecode(
             b'00ffc00ac0140088008700390038c00fc00500840035c007c009c011c0130045004400330032c00c'
@@ -694,8 +695,13 @@ class TestServerHello(object):
     def test_random_correct(self):
         assert (self.p.data.random == _hexdecode(b'5008220c8ec43c5462315a7c99f5d5b6bff009ad285b51dc18485f352e9fdecd'))
 
-    def test_cipher_suite(self):
-        assert (self.p.data.cipher_suite.name == 'TLS_RSA_WITH_NULL_SHA')
+    def test_ciphersuite(self):
+        assert (self.p.data.ciphersuite.name == 'TLS_RSA_WITH_NULL_SHA')
+        assert (self.p.data.cipher_suite.name == 'TLS_RSA_WITH_NULL_SHA')  # deprecated; still test for coverage
+
+    def test_compression_method(self):
+        assert (self.p.data.compression_method == 0)
+        assert (self.p.data.compression == 0)  # deprecated; still test for coverage
 
     def test_total_length(self):
         assert (len(self.p) == 81)

--- a/dpkt/ssl.py
+++ b/dpkt/ssl.py
@@ -9,7 +9,7 @@ import binascii
 
 from . import dpkt
 from . import ssl_ciphersuites
-from .compat import compat_ord
+from .compat import compat_ord, deprecation_warning
 
 #
 # Note from April 2011: cde...@gmail.com added code that parses SSL3/TLS messages more in depth.
@@ -342,10 +342,17 @@ class TLSServerHello(dpkt.Packet):
             # probably data too short
             raise dpkt.NeedData
 
-        # XXX - legacy, to be deprecated
-        # for whatever reason these attributes were named differently than their sister attributes in TLSClientHello
-        self.cipher_suite = self.ciphersuite
-        self.compression = self.compression_method
+    # XXX - legacy, deprecated
+    # for whatever reason these attributes were named differently than their sister attributes in TLSClientHello
+    @property
+    def cipher_suite(self):
+        deprecation_warning("TLSServerHello.cipher_suite is deprecated and renamed to .ciphersuite")
+        return self.ciphersuite
+
+    @property
+    def compression(self):
+        deprecation_warning("TLSServerHello.compression is deprecated and renamed to .compression_method")
+        return self.compression_method
 
 
 class TLSCertificate(dpkt.Packet):

--- a/dpkt/tcp.py
+++ b/dpkt/tcp.py
@@ -73,42 +73,18 @@ class TCP(dpkt.Packet):
         ('sum', 'H', 0),
         ('urp', 'H', 0)
     )
-
+    __bit_fields__ = {
+        '_off_flags': [
+            ('off', 4),    # 4 hi bits
+            ('_rsv', 3),   # 3 bits reserved
+            ('flags', 9),  # 9 lo bits
+        ]
+    }
     __pprint_funcs__ = {
         'flags': tcp_flags_to_str,
         'sum': hex,  # display checksum in hex
     }
-
     opts = b''
-
-    # getters and setters to process _off_flags
-
-    #   0   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15
-    # +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
-    # |               |           | N | C | E | U | A | P | R | S | F |
-    # | Header Length | Reserved  | S | W | C | R | C | S | S | Y | I |
-    # |               |           |   | R | E | G | K | H | T | N | N |
-    # +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
-
-    @property
-    def off(self):
-        # 2-byte word = 16 bits; shift right 12 bits to get 4 hi bits
-        return self._off_flags >> 12
-
-    @off.setter
-    def off(self, off):
-        # 2-byte word with 4 hi bits zeroed = 0b0000111111111111 = 0x0fff
-        self._off_flags = (off << 12) | (self._off_flags & 0xfff)
-
-    @property
-    def flags(self):
-        # 9 lo bits 0b111111111 = 0x1ff
-        return self._off_flags & 0x1ff
-
-    @flags.setter
-    def flags(self, flags):
-        # 2-byte word with 9 lo bits zeroed = 0b1111111000000000 = 0xfe00
-        self._off_flags = (self._off_flags & 0xfe00) | flags
 
     def __len__(self):
         return self.__hdr_len__ + len(self.opts) + len(self.data)

--- a/dpkt/tcp.py
+++ b/dpkt/tcp.py
@@ -74,11 +74,11 @@ class TCP(dpkt.Packet):
         ('urp', 'H', 0)
     )
     __bit_fields__ = {
-        '_off_flags': [
+        '_off_flags': (
             ('off', 4),    # 4 hi bits
             ('_rsv', 3),   # 3 bits reserved
             ('flags', 9),  # 9 lo bits
-        ]
+        )
     }
     __pprint_funcs__ = {
         'flags': tcp_flags_to_str,

--- a/dpkt/utils.py
+++ b/dpkt/utils.py
@@ -1,11 +1,12 @@
 """Various Utility Functions"""
 import socket
+import warnings
 from .compat import compat_ord
 from .dns import DNS
 
 
 def mac_to_str(address):
-    """Convert a MAC address to a readable/printable string
+    r"""Convert a MAC address to a readable/printable string
 
        Args:
            address (str): a MAC address in hex form (e.g. '\x01\x02\x03\x04\x05\x06')
@@ -31,8 +32,7 @@ def inet_to_str(inet):
 
 
 def make_dict(obj):
-    """This method creates a dictionary out of a non-builtin object"""
-
+    """Create a dictionary out of a non-builtin object"""
     # Recursion base case
     if is_builtin(obj):
         return obj
@@ -48,12 +48,16 @@ def make_dict(obj):
             else:
                 output_dict[key] = make_dict(attr)
 
-    # All done
     return output_dict
 
 
 def is_builtin(obj):
     return obj.__class__.__module__ in ['__builtin__', 'builtins']
+
+
+def deprecation_warning(*args):
+    """print a deprecation warning"""
+    warnings.warn(*args, stacklevel=2)
 
 
 def test_utils():

--- a/dpkt/vrrp.py
+++ b/dpkt/vrrp.py
@@ -26,24 +26,15 @@ class VRRP(dpkt.Packet):
         ('advtime', 'B', 0),
         ('sum', 'H', 0),
     )
+    __bit_fields__ = {
+        '_v_type': [
+            ('v', 4),
+            ('type', 4)
+        ]
+    }
+
     addrs = ()
     auth = ''
-
-    @property
-    def v(self):  # high 4 bits of _v_type
-        return self._v_type >> 4
-
-    @v.setter
-    def v(self, v):
-        self._v_type = (self._v_type & 0x0f) | (v << 4)
-
-    @property
-    def type(self):  # low 4 bits of _v_type
-        return self._v_type & 0x0f
-
-    @type.setter
-    def type(self, v):
-        self._v_type = (self._v_type & 0xf0) | (v & 0x0f)
 
     def unpack(self, buf):
         dpkt.Packet.unpack(self, buf)

--- a/dpkt/vrrp.py
+++ b/dpkt/vrrp.py
@@ -27,10 +27,10 @@ class VRRP(dpkt.Packet):
         ('sum', 'H', 0),
     )
     __bit_fields__ = {
-        '_v_type': [
+        '_v_type': (
             ('v', 4),
-            ('type', 4)
-        ]
+            ('type', 4),
+        )
     }
 
     addrs = ()


### PR DESCRIPTION
This is a large diff but the main changes are in `dpkt.py`.
I realized the existing mechanism of creating bit fields (i.e. fields that translate into multiple attributes, such as IP flags) and their accompanying properties
1. had issues with complex names like `m_flag` (wrongly decoded into `m` and `flag`), `age` and `max_age` (decoded into two attributes named `age`), etc.
2. the property creation is a repeated boilerplate pattern that could be automated in the metaclass, making it easier and less error prone to create new protocol parsers.
3. had issues with output in `repr()` since bit field properties had no concept of their default value.
4. had no bounds checking so assigning a value too large would overflow and corrupt the neighboring field.
5. was completely undocumented.

Enter `__bit_fields__`, addressing all the shortcomings above and allowing to replace code like this:
```
class IP(dpkt.Packet):
    __hdr__ = (
        ('_v_hl', 'B', (4 << 4) | (20 >> 2)),
        ...
    )
    @property
    def v(self):
        return self._v_hl >> 4

    @v.setter
    def v(self, v):
        self._v_hl = (v << 4) | (self._v_hl & 0xf)

    @property
    def hl(self):
        return self._v_hl & 0xf

    @hl.setter
    def hl(self, hl):
        self._v_hl = (self._v_hl & 0xf0) | hl
```

with this:
```
class IP(dpkt.Packet):
    __hdr__ = (
        ('_v_hl', 'B', (4 << 4) | (20 >> 2)),
        ...
    )
    __bit_fields__ = {
        '_v_hl': (
            ('v', 4),   # version, 4 bits
            ('hl', 4),  # header len, 4 bits
        )
    }
```
The addition enhances the metaclass so that the getter and setter properties can be created automagically, plus the delete property, allowing to reset the bit field back to its default value. It also adds bounds checking to the setter property, so an exception will be raised if the given value won't fit into the number of bits allocated. 

The `__bit_fields__` is completely optional and doesn't change the existing logic; all the magic happens in the metaclass `__new__` method so shouldn't affect the performance of packet processing.

Another change in this PR is addition of `__public_fields__` which simply refactors and DRYs out some common code between `__repr__` and `pprint()`.

The remaining changes are just refactoring edits to the protocol parsers to replace explicit properties with `__bit_fields__` definitions. Note there are almost no changes to unit tests. 

Finally, I took a stab at documenting all of these new features alongside with the existing logic of the protocol parsers, hopefully making it easier for other(new) contributors to the project (docs/creating_parsers.rst). The doc is not referenced anywhere in the document tree, I'm happy to add it somewhere (taking suggestions @brifordwylie), or simply add it as-is and let it get integrated with the future doc improvements.