### PR TITLE
Add IPv6 support to MPLS.

### DIFF
--- a/dpkt/ethernet.py
+++ b/dpkt/ethernet.py
@@ -118,7 +118,7 @@ class Ethernet(dpkt.Packet):
             if compat_ord(buf[0]) == 0x45:  # IP version 4 + header len 20 bytes
                 self._next_type = ETH_TYPE_IP
 
-            elif ( compat_ord(buf[0]) & 0xf0 ) >> 4 == 6:  # IP version 6 
+            elif compat_ord(buf[0]) & 0xf0 == 0x60:  # IP version 6 
                 self._next_type = ETH_TYPE_IP6
 
             # pseudowire Ethernet

--- a/dpkt/ethernet.py
+++ b/dpkt/ethernet.py
@@ -614,7 +614,7 @@ def test_eth_mpls_ipv6():  # Eth - MPLS - IP6 - TCP
           b'\x05\x8c\x04\x02\x08\x0a\x69\x23\xe8\x63\x00\x00\x00\x00\x01\x03'
           b'\x03\x0a\xaf\x9c\xb6\x93')
 
-    eth = dpkt.ethernet.Ethernet(s)
+    eth = Ethernet(s)
     assert len(eth.mpls_labels) == 1
     assert eth.mpls_labels[0].val == 16
     assert eth.labels == [(16, 0, 255)]


### PR DESCRIPTION
Very small change to add IPv6 support to MPLS following the same approach used for IPv4.