### PR TITLE
Graceful handling of PCAPNG option comment UTF-8 decoding errors

### DIFF
--- a/docs/authors.md
+++ b/docs/authors.md
@@ -74,6 +74,6 @@ Dug Song \<<dugsong@monkey.org>\>
     Extend test coverage
 
   - Schwaggot \<<tom.ryan@posteo.de>\>  
-    Graceful handling of PCAPNG option comment UTF-8 decoding errors
+    pcapng module, support for Packet Block and handling of UTF-8 option comments
 
 If you want to contribute to dpkt, see `contributing`.

--- a/docs/authors.md
+++ b/docs/authors.md
@@ -73,4 +73,7 @@ Dug Song \<<dugsong@monkey.org>\>
   - crocogorical \<<crocogorical@gmail.com>\>  
     Extend test coverage
 
+  - Schwaggot \<<tom.ryan@posteo.de>\>  
+    Graceful handling of PCAPNG option comment UTF-8 decoding errors
+
 If you want to contribute to dpkt, see `contributing`.

--- a/dpkt/pcapng.py
+++ b/dpkt/pcapng.py
@@ -194,7 +194,7 @@ class PcapngOption(dpkt.Packet):
                 self.text = self.data.decode('utf-8')
             except UnicodeDecodeError as ude:
                 if b'\x00' in self.data:
-                    self.text = self.data[0:self.data.index(b'\x00')]
+                    self.text = self.data[0:self.data.index(b'\x00')].decode('ascii')
                 else:
                     raise ude
 

--- a/dpkt/pcapng.py
+++ b/dpkt/pcapng.py
@@ -20,35 +20,35 @@ PCAPNG_VERSION_MAJOR = 1
 PCAPNG_VERSION_MINOR = 0
 
 # Block types
-PCAPNG_BT_IDB = 0x00000001  # Interface Description Block
-PCAPNG_BT_PB = 0x00000002  # Packet Block (deprecated)
-PCAPNG_BT_SPB = 0x00000003  # Simple Packet Block
-PCAPNG_BT_EPB = 0x00000006  # Enhanced Packet Block
-PCAPNG_BT_SHB = 0x0A0D0D0A  # Section Header Block
+PCAPNG_BT_IDB = 0x00000001     # Interface Description Block
+PCAPNG_BT_PB = 0x00000002      # Packet Block (deprecated)
+PCAPNG_BT_SPB = 0x00000003     # Simple Packet Block
+PCAPNG_BT_EPB = 0x00000006     # Enhanced Packet Block
+PCAPNG_BT_SHB = 0x0A0D0D0A     # Section Header Block
 
 # Options
-PCAPNG_OPT_ENDOFOPT = 0  # end of options
-PCAPNG_OPT_COMMENT = 1  # comment
+PCAPNG_OPT_ENDOFOPT = 0        # end of options
+PCAPNG_OPT_COMMENT = 1         # comment
 
 # SHB options
-PCAPNG_OPT_SHB_HARDWARE = 2  # description of the hardware
-PCAPNG_OPT_SHB_OS = 3  # name of the operating system
-PCAPNG_OPT_SHB_USERAPPL = 4  # name of the application
+PCAPNG_OPT_SHB_HARDWARE = 2    # description of the hardware
+PCAPNG_OPT_SHB_OS = 3          # name of the operating system
+PCAPNG_OPT_SHB_USERAPPL = 4    # name of the application
 
 # IDB options
-PCAPNG_OPT_IF_NAME = 2  # interface name
+PCAPNG_OPT_IF_NAME = 2         # interface name
 PCAPNG_OPT_IF_DESCRIPTION = 3  # interface description
-PCAPNG_OPT_IF_IPV4ADDR = 4  # IPv4 network address and netmask for the interface
-PCAPNG_OPT_IF_IPV6ADDR = 5  # IPv6 network address and prefix length for the interface
-PCAPNG_OPT_IF_MACADDR = 6  # interface hardware MAC address
-PCAPNG_OPT_IF_EUIADDR = 7  # interface hardware EUI address
-PCAPNG_OPT_IF_SPEED = 8  # interface speed in bits/s
-PCAPNG_OPT_IF_TSRESOL = 9  # timestamp resolution
-PCAPNG_OPT_IF_TZONE = 10  # time zone
-PCAPNG_OPT_IF_FILTER = 11  # capture filter
-PCAPNG_OPT_IF_OS = 12  # operating system
-PCAPNG_OPT_IF_FCSLEN = 13  # length of the Frame Check Sequence in bits
-PCAPNG_OPT_IF_TSOFFSET = 14  # offset (in seconds) that must be added to packet timestamp
+PCAPNG_OPT_IF_IPV4ADDR = 4     # IPv4 network address and netmask for the interface
+PCAPNG_OPT_IF_IPV6ADDR = 5     # IPv6 network address and prefix length for the interface
+PCAPNG_OPT_IF_MACADDR = 6      # interface hardware MAC address
+PCAPNG_OPT_IF_EUIADDR = 7      # interface hardware EUI address
+PCAPNG_OPT_IF_SPEED = 8        # interface speed in bits/s
+PCAPNG_OPT_IF_TSRESOL = 9      # timestamp resolution
+PCAPNG_OPT_IF_TZONE = 10       # time zone
+PCAPNG_OPT_IF_FILTER = 11      # capture filter
+PCAPNG_OPT_IF_OS = 12          # operating system
+PCAPNG_OPT_IF_FCSLEN = 13      # length of the Frame Check Sequence in bits
+PCAPNG_OPT_IF_TSOFFSET = 14    # offset (in seconds) that must be added to packet timestamp
 
 # <copied from pcap.py>
 DLT_NULL = 0
@@ -78,8 +78,6 @@ else:
 dltoff = {DLT_NULL: 4, DLT_EN10MB: 14, DLT_IEEE802: 22, DLT_ARCNET: 6,
           DLT_SLIP: 16, DLT_PPP: 4, DLT_FDDI: 21, DLT_PFLOG: 48, DLT_PFSYNC: 4,
           DLT_LOOP: 4, DLT_LINUX_SLL: 16}
-
-
 # </copied from pcap.py>
 
 
@@ -538,7 +536,7 @@ class Reader(object):
 
         # check if this version is supported
         if shb.v_major != PCAPNG_VERSION_MAJOR:
-            raise ValueError('unknown pcapng version {0}.{1}'.format(shb.v_major, shb.v_minor, ))
+            raise ValueError('unknown pcapng version {0}.{1}'.format(shb.v_major, shb.v_minor,))
 
         # look for a mandatory IDB
         idb = None
@@ -603,7 +601,6 @@ class Reader(object):
 
     def __next__(self):
         return next(self.__iter)
-
     next = __next__  # Python 2 compat
 
     def dispatch(self, cnt, callback, *args):
@@ -957,7 +954,6 @@ def pre_test(f):
         fobj.seek(0)
 
         return ret
-
     return wrapper
 
 
@@ -970,7 +966,6 @@ class WriterTestWrap:
     After the test has run, the BytesIO object will be passed to a Reader,
     which will compare each pkt to the return value of the test.
     """
-
     def __init__(self, *args, **kwargs):
         self.args = args
         self.kwargs = kwargs
@@ -998,7 +993,6 @@ class WriterTestWrap:
                 Writer._Writer__le = _sysle
                 del f.__globals__['writer']
                 del f.__globals__['fobj']
-
         return wrapper
 
 
@@ -1033,7 +1027,6 @@ class PostTest:
                 assert comp == ret
             else:
                 raise Exception("No test type specified")
-
         return wrapper
 
 
@@ -1066,7 +1059,7 @@ def test_shb_version():
 @pre_test
 def test_no_idb():
     shb = define_testdata().valid_shb_le
-    fobj.write(bytes(shb) + b'aaaa')  # noqa
+    fobj.write(bytes(shb)+b'aaaa')  # noqa
 
 
 @PostTest(test='compare_property', property='idb')
@@ -1078,8 +1071,8 @@ def test_idb_opt_offset():
     idb.opts.insert(0, PcapngOptionLE(
         code=PCAPNG_OPT_IF_TSOFFSET,
         data=struct_pack('<q', 123456666))
-                    )
-    fobj.write(bytes(shb) + bytes(idb))  # noqa
+    )
+    fobj.write(bytes(shb)+bytes(idb))  # noqa
     return idb
 
 
@@ -1090,7 +1083,7 @@ def test_idb_linktype():
     shb = define_testdata().valid_shb_le
     idb = define_testdata().valid_idb_le
     idb.linktype = 3456
-    fobj.write(bytes(shb) + bytes(idb))  # noqa
+    fobj.write(bytes(shb)+bytes(idb))  # noqa
     return 0
 
 
@@ -1259,7 +1252,6 @@ def test_writepkt_epb_ts():
 
     def time():
         return ts
-
     writer.writepkt(epb)
     time = _tmp
 
@@ -1310,7 +1302,6 @@ def test_writepkt_no_time():
 
     def time():
         return ts
-
     writer.writepkt(pkt)  # noqa
     time = _tmp
     return [(ts, pkt)]
@@ -1401,7 +1392,6 @@ def test_reader_file_descriptor():
 
 def test_posttest():
     """Check that PostTest wrapper doesn't fail silently"""
-
     @PostTest()
     @pre_test
     def fun():

--- a/dpkt/pcapng.py
+++ b/dpkt/pcapng.py
@@ -20,35 +20,35 @@ PCAPNG_VERSION_MAJOR = 1
 PCAPNG_VERSION_MINOR = 0
 
 # Block types
-PCAPNG_BT_IDB = 0x00000001     # Interface Description Block
-PCAPNG_BT_PB = 0x00000002      # Packet Block (deprecated)
-PCAPNG_BT_SPB = 0x00000003     # Simple Packet Block
-PCAPNG_BT_EPB = 0x00000006     # Enhanced Packet Block
-PCAPNG_BT_SHB = 0x0A0D0D0A     # Section Header Block
+PCAPNG_BT_IDB = 0x00000001  # Interface Description Block
+PCAPNG_BT_PB = 0x00000002  # Packet Block (deprecated)
+PCAPNG_BT_SPB = 0x00000003  # Simple Packet Block
+PCAPNG_BT_EPB = 0x00000006  # Enhanced Packet Block
+PCAPNG_BT_SHB = 0x0A0D0D0A  # Section Header Block
 
 # Options
-PCAPNG_OPT_ENDOFOPT = 0        # end of options
-PCAPNG_OPT_COMMENT = 1         # comment
+PCAPNG_OPT_ENDOFOPT = 0  # end of options
+PCAPNG_OPT_COMMENT = 1  # comment
 
 # SHB options
-PCAPNG_OPT_SHB_HARDWARE = 2    # description of the hardware
-PCAPNG_OPT_SHB_OS = 3          # name of the operating system
-PCAPNG_OPT_SHB_USERAPPL = 4    # name of the application
+PCAPNG_OPT_SHB_HARDWARE = 2  # description of the hardware
+PCAPNG_OPT_SHB_OS = 3  # name of the operating system
+PCAPNG_OPT_SHB_USERAPPL = 4  # name of the application
 
 # IDB options
-PCAPNG_OPT_IF_NAME = 2         # interface name
+PCAPNG_OPT_IF_NAME = 2  # interface name
 PCAPNG_OPT_IF_DESCRIPTION = 3  # interface description
-PCAPNG_OPT_IF_IPV4ADDR = 4     # IPv4 network address and netmask for the interface
-PCAPNG_OPT_IF_IPV6ADDR = 5     # IPv6 network address and prefix length for the interface
-PCAPNG_OPT_IF_MACADDR = 6      # interface hardware MAC address
-PCAPNG_OPT_IF_EUIADDR = 7      # interface hardware EUI address
-PCAPNG_OPT_IF_SPEED = 8        # interface speed in bits/s
-PCAPNG_OPT_IF_TSRESOL = 9      # timestamp resolution
-PCAPNG_OPT_IF_TZONE = 10       # time zone
-PCAPNG_OPT_IF_FILTER = 11      # capture filter
-PCAPNG_OPT_IF_OS = 12          # operating system
-PCAPNG_OPT_IF_FCSLEN = 13      # length of the Frame Check Sequence in bits
-PCAPNG_OPT_IF_TSOFFSET = 14    # offset (in seconds) that must be added to packet timestamp
+PCAPNG_OPT_IF_IPV4ADDR = 4  # IPv4 network address and netmask for the interface
+PCAPNG_OPT_IF_IPV6ADDR = 5  # IPv6 network address and prefix length for the interface
+PCAPNG_OPT_IF_MACADDR = 6  # interface hardware MAC address
+PCAPNG_OPT_IF_EUIADDR = 7  # interface hardware EUI address
+PCAPNG_OPT_IF_SPEED = 8  # interface speed in bits/s
+PCAPNG_OPT_IF_TSRESOL = 9  # timestamp resolution
+PCAPNG_OPT_IF_TZONE = 10  # time zone
+PCAPNG_OPT_IF_FILTER = 11  # capture filter
+PCAPNG_OPT_IF_OS = 12  # operating system
+PCAPNG_OPT_IF_FCSLEN = 13  # length of the Frame Check Sequence in bits
+PCAPNG_OPT_IF_TSOFFSET = 14  # offset (in seconds) that must be added to packet timestamp
 
 # <copied from pcap.py>
 DLT_NULL = 0
@@ -78,6 +78,8 @@ else:
 dltoff = {DLT_NULL: 4, DLT_EN10MB: 14, DLT_IEEE802: 22, DLT_ARCNET: 6,
           DLT_SLIP: 16, DLT_PPP: 4, DLT_FDDI: 21, DLT_PFLOG: 48, DLT_PFSYNC: 4,
           DLT_LOOP: 4, DLT_LINUX_SLL: 16}
+
+
 # </copied from pcap.py>
 
 
@@ -536,7 +538,7 @@ class Reader(object):
 
         # check if this version is supported
         if shb.v_major != PCAPNG_VERSION_MAJOR:
-            raise ValueError('unknown pcapng version {0}.{1}'.format(shb.v_major, shb.v_minor,))
+            raise ValueError('unknown pcapng version {0}.{1}'.format(shb.v_major, shb.v_minor, ))
 
         # look for a mandatory IDB
         idb = None
@@ -601,6 +603,7 @@ class Reader(object):
 
     def __next__(self):
         return next(self.__iter)
+
     next = __next__  # Python 2 compat
 
     def dispatch(self, cnt, callback, *args):
@@ -765,6 +768,50 @@ def test_epb():
     assert len(epb) == len(buf)
 
 
+def test_epb_ascii_comment_option():
+    """Test EPB with an ascii comment option"""
+    buf = (
+        b'\x06\x00\x00\x00\x7c\x00\x00\x00\x01\x00\x00\x00\xff\xff\xff\xff\x79\xd2\xdf\xe1\x44\x00'
+        b'\x00\x00\x44\x00\x00\x00\x00\x00\x00\x01\x00\x06\x00\x0b\xdb\x43\xe7\x4b\xf6\x7f\x08\x00'
+        b'\x45\x00\x00\x34\x2b\x1f\x40\x00\x40\x06\x15\x63\x82\xd9\xfa\x81\x82\xd9\xfa\x0d\x17\x70'
+        b'\xec\x3e\x02\xba\x94\x38\x81\x52\x4a\x39\x80\x10\xbb\x5d\x53\x0d\x00\x00\x01\x01\x08\x0a'
+        b'\x03\xf9\xc7\xbf\x04\x02\x38\x28\x01\x00\x0f\x00\x50\x61\x63\x6b\x65\x74\x20\x23\x31\x00'
+        b'\x78\x4d\x39\x87\x0c\x00\x00\x00\x00\x00\x7c\x00\x00\x00')
+
+    # block unpacking
+    epb = EnhancedPacketBlockLE(buf)
+
+    # options unpacking
+    assert len(epb.opts) == 2
+    assert epb.opts[0].code == PCAPNG_OPT_COMMENT
+    assert epb.opts[0].text == 'Packet #1'
+
+    assert epb.opts[1].code == PCAPNG_OPT_ENDOFOPT
+    assert epb.opts[1].len == 0
+
+    # option packing
+    assert bytes(epb.opts[0]) == b'\x01\x00\x09\x00\x50\x61\x63\x6b\x65\x74\x20\x23\x31\x00\x00\x00'
+    assert len(epb.opts[0]) == 16
+    assert bytes(epb.opts[1]) == b'\x00\x00\x00\x00'
+
+
+def test_epb_invalid_utf8_comment_option():
+    """Test EPB with an invalid (non UTF-8, non-zero terminated ascii) comment option"""
+    buf = (
+        b'\x06\x00\x00\x00\x7c\x00\x00\x00\x01\x00\x00\x00\xff\xff\xff\xff\x79\xd2\xdf\xe1\x44\x00'
+        b'\x00\x00\x44\x00\x00\x00\x00\x00\x00\x01\x00\x06\x00\x0b\xdb\x43\xe7\x4b\xf6\x7f\x08\x00'
+        b'\x45\x00\x00\x34\x2b\x1f\x40\x00\x40\x06\x15\x63\x82\xd9\xfa\x81\x82\xd9\xfa\x0d\x17\x70'
+        b'\xec\x3e\x02\xba\x94\x38\x81\x52\x4a\x39\x80\x10\xbb\x5d\x53\x0d\x00\x00\x01\x01\x08\x0a'
+        b'\x03\xf9\xc7\xbf\x04\x02\x38\x28\x01\x00\x0f\x00\x50\x61\x63\x6b\x65\x74\x20\x23\x31\x20'
+        b'\x78\x4d\x39\x87\x0c\x00\x00\x00\x00\x00\x7c\x00\x00\x00')
+
+    try:
+        EnhancedPacketBlockLE(buf)
+        assert False
+    except Exception as e:
+        assert isinstance(e, UnicodeDecodeError)
+
+
 def test_simple_write_read():
     """Test writing a basic pcapng and then reading it"""
     fobj = BytesIO()
@@ -910,6 +957,7 @@ def pre_test(f):
         fobj.seek(0)
 
         return ret
+
     return wrapper
 
 
@@ -922,6 +970,7 @@ class WriterTestWrap:
     After the test has run, the BytesIO object will be passed to a Reader,
     which will compare each pkt to the return value of the test.
     """
+
     def __init__(self, *args, **kwargs):
         self.args = args
         self.kwargs = kwargs
@@ -949,6 +998,7 @@ class WriterTestWrap:
                 Writer._Writer__le = _sysle
                 del f.__globals__['writer']
                 del f.__globals__['fobj']
+
         return wrapper
 
 
@@ -983,6 +1033,7 @@ class PostTest:
                 assert comp == ret
             else:
                 raise Exception("No test type specified")
+
         return wrapper
 
 
@@ -1015,7 +1066,7 @@ def test_shb_version():
 @pre_test
 def test_no_idb():
     shb = define_testdata().valid_shb_le
-    fobj.write(bytes(shb)+b'aaaa')  # noqa
+    fobj.write(bytes(shb) + b'aaaa')  # noqa
 
 
 @PostTest(test='compare_property', property='idb')
@@ -1027,8 +1078,8 @@ def test_idb_opt_offset():
     idb.opts.insert(0, PcapngOptionLE(
         code=PCAPNG_OPT_IF_TSOFFSET,
         data=struct_pack('<q', 123456666))
-    )
-    fobj.write(bytes(shb)+bytes(idb))  # noqa
+                    )
+    fobj.write(bytes(shb) + bytes(idb))  # noqa
     return idb
 
 
@@ -1039,7 +1090,7 @@ def test_idb_linktype():
     shb = define_testdata().valid_shb_le
     idb = define_testdata().valid_idb_le
     idb.linktype = 3456
-    fobj.write(bytes(shb)+bytes(idb))  # noqa
+    fobj.write(bytes(shb) + bytes(idb))  # noqa
     return 0
 
 
@@ -1208,6 +1259,7 @@ def test_writepkt_epb_ts():
 
     def time():
         return ts
+
     writer.writepkt(epb)
     time = _tmp
 
@@ -1258,6 +1310,7 @@ def test_writepkt_no_time():
 
     def time():
         return ts
+
     writer.writepkt(pkt)  # noqa
     time = _tmp
     return [(ts, pkt)]
@@ -1348,6 +1401,7 @@ def test_reader_file_descriptor():
 
 def test_posttest():
     """Check that PostTest wrapper doesn't fail silently"""
+
     @PostTest()
     @pre_test
     def fun():

--- a/dpkt/pcapng.py
+++ b/dpkt/pcapng.py
@@ -194,7 +194,7 @@ class PcapngOption(dpkt.Packet):
                 self.text = self.data.decode('utf-8')
             except UnicodeDecodeError as ude:
                 if b'\x00' in self.data:
-                    self.text = self.data[0:self.data.index(b'\x00')].decode('ascii')
+                    self.text = self.data[:self.data.index(b'\x00')].decode('ascii')
                 else:
                     raise ude
 

--- a/dpkt/pcapng.py
+++ b/dpkt/pcapng.py
@@ -804,7 +804,6 @@ def test_epb_invalid_utf8_comment_option():
 
     try:
         EnhancedPacketBlockLE(buf)
-        assert False
     except Exception as e:
         assert isinstance(e, UnicodeDecodeError)
 

--- a/dpkt/pcapng.py
+++ b/dpkt/pcapng.py
@@ -190,7 +190,13 @@ class PcapngOption(dpkt.Packet):
 
         # decode comment
         if self.code == PCAPNG_OPT_COMMENT:
-            self.text = self.data.decode('utf-8')
+            try:
+                self.text = self.data.decode('utf-8')
+            except UnicodeDecodeError as ude:
+                if b'\x00' in self.data:
+                    self.text = self.data[0:self.data.index(b'\x00')]
+                else:
+                    raise ude
 
     def __bytes__(self):
         # encode comment


### PR DESCRIPTION
I believe before the current PCAPNG standard it was customary to have zero-terminated C-strings as comments, similar to the PCAP format. Although by now deprecated and switched to UTF-8 strings there are still capture files out there that have this old format. At the moment dpkt would just crash with a `UnicodeDecodeError` while trying to read these comments, which is a bit harsh for a field that has usually no contribution to the capture itself.

When merged this will add gracefull support for UTF-8 decoding errors, i.e., it will first try to parse comments as UTF-8 (new standard), if that fails it will check whether the data contains a zero-terminator and interpret it as a C-string. If no zero-terminator is found, the `UnicodeDecodeError` will still be raised (as previously).