### PR TITLE
Use int precision multiplier instead of float

### DIFF
--- a/dpkt/pcapng.py
+++ b/dpkt/pcapng.py
@@ -608,7 +608,7 @@ class Reader(object):
             raise ValueError('IDB not found')
 
         # set timestamp resolution and offset
-        self._divisor = float(1e6)  # defaults
+        self._divisor = 1000000  # defaults
         self._tsoffset = 0
         for opt in idb.opts:
             if opt.code == PCAPNG_OPT_IF_TSRESOL:
@@ -616,7 +616,7 @@ class Reader(object):
                 # if MSB=1, the remaining bits is a neg power of 2 (e.g. 10 means 1/1024 of second)
                 opt_val = struct_unpack('b', opt.data)[0]
                 pow_num = 2 if opt_val & 0b10000000 else 10
-                self._divisor = float(pow_num ** (opt_val & 0b01111111))
+                self._divisor = pow_num ** (opt_val & 0b01111111)
 
             elif opt.code == PCAPNG_OPT_IF_TSOFFSET:
                 # 64-bit int that specifies an offset (in seconds) that must be added to the

--- a/dpkt/pcapng.py
+++ b/dpkt/pcapng.py
@@ -421,6 +421,7 @@ class Writer(object):
         idb can be an instance of InterfaceDescriptionBlock(LE) (or sequence of them)
         """
         self.__f = fileobj
+        self._precision_multiplier = 1_000_000
 
         if shb:
             self._validate_block('shb', shb, SectionHeaderBlock)
@@ -471,9 +472,9 @@ class Writer(object):
             self._validate_block('pkt', pkt, EnhancedPacketBlock)
 
             if ts is not None:  # ts as an argument gets precedence
-                ts = intround(ts * 1e6)
+                ts = intround(ts * self._precision_multiplier)
             elif pkt.ts_high == pkt.ts_low == 0:
-                ts = intround(time() * 1e6)
+                ts = intround(time() * self._precision_multiplier)
 
             if ts is not None:
                 pkt.ts_high = ts >> 32
@@ -495,7 +496,7 @@ class Writer(object):
             pkt: a buffer
             ts: Unix timestamp in seconds since Epoch (e.g. 1454725786.99)
         """
-        ts = intround(ts * 1e6)  # to int microseconds
+        ts = intround(ts * self._precision_multiplier)  # to int microseconds
 
         s = pkt
         n = len(s)
@@ -527,7 +528,7 @@ class Writer(object):
         precalc_n = hdr_len + opts_len
 
         for ts, pkt in pkts:
-            ts = intround(ts * 1e6)  # to int microseconds
+            ts = intround(ts * self._precision_multiplier)  # int microseconds
             pkt_len = len(pkt)
             pkt_len_align = _align32b(pkt_len)
 

--- a/dpkt/pcapng.py
+++ b/dpkt/pcapng.py
@@ -421,7 +421,7 @@ class Writer(object):
         idb can be an instance of InterfaceDescriptionBlock(LE) (or sequence of them)
         """
         self.__f = fileobj
-        self._precision_multiplier = 1_000_000
+        self._precision_multiplier = 1000000
 
         if shb:
             self._validate_block('shb', shb, SectionHeaderBlock)

--- a/dpkt/pcapng.py
+++ b/dpkt/pcapng.py
@@ -5,6 +5,7 @@
 # pylint: disable=attribute-defined-outside-init
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import division  # so python 2 doesn't do integer division
 
 from struct import pack as struct_pack, unpack as struct_unpack
 from time import time


### PR DESCRIPTION
This code change is very straightforward (`1e6` -> `1_000_000`), but I'll explain the backstory.

I have a software utility that writes to either pcap or pcapng - I'm sure many people do, the API is the same which makes it very easy :D 

Except! We have nanosecond resolution timestamps. So we're using nano=True for pcap (not supported in pcapng, that's fine).

It turns out that floats do not have sufficient precision to encode a UNIX timestamp with small nanosecond differences, so we use `Decimal` for our timestamp. 
This is all well and good for pcap files (which multiply the timestamp by an integer), but no good for pcap, which multiplies the timestamp by 1e6 (which is a float).

So, in my project, I _could_ do something like `if pcapng, convert timestamp to float`.

But it's a lot cleaner if dpkt could replace the constant `1e6` with `1_000_000`. Then I can simply pass a Decimal into either Writer type :sunglasses: 

I also converted it from being a magic number in 4 places to a variable, this might help if someone in the future feels like expanding the pcapng Writer to support nanoseconds (if the file format permits?)... :wink: 