### PR TITLE
Fix tls records unpacking

### DIFF
--- a/dpkt/ssl.py
+++ b/dpkt/ssl.py
@@ -62,16 +62,15 @@ class TLS(dpkt.Packet):
         dpkt.Packet.__init__(self, *args, **kwargs)
 
     def unpack(self, buf):
+        # this either unpacks the entire buffer into 1 or multiple TLSRecord's 
+        # or throws NeedData if the buffer is incomplete (truncated).
+        # tls_multi_factory() will do the same, but gracefully; it will unpack 
+        # multiple TLS records and catch NeedData if the buffer was incomplete
         while buf:
-            try:
-                tlsrec = TLSRecord(buf)
-            except dpkt.NeedData:
-                break
-            else:
-                self.records.append(tlsrec)
-                buf = buf[5 + tlsrec.length:]  # 5 = TLSRecord.__hdr_len__
-
-        self.data = buf  # remaining data, if any
+            tlsrec = TLSRecord(buf)
+            self.records.append(tlsrec)
+            buf = buf[5 + tlsrec.length:]  # 5 = TLSRecord.__hdr_len__
+        self.data = b''
 
 
 # SSLv3/TLS versions

--- a/dpkt/ssl.py
+++ b/dpkt/ssl.py
@@ -71,9 +71,6 @@ class TLS(dpkt.Packet):
                 self.records.append(tlsrec)
                 buf = buf[5 + tlsrec.length:]  # 5 = TLSRecord.__hdr_len__
 
-                if tlsrec.type in RECORD_TYPES:
-                    tlsrec.data = RECORD_TYPES[tlsrec.type](tlsrec.data)
-
         self.data = buf  # remaining data, if any
 
 


### PR DESCRIPTION
Refactor unpacking of TLS. 
`class TLS` is just a container for `TLSRecord`s.  As such, it doesn't need its own `__hdr__`. In current code it just copies the header of the 1st `TLSRecord`, which is technically incorrect. 
A better pattern would be that `TLS` delegates unpacking to the underlying `TLSRecord` and advances the buffer. The proposed change does just that.