### PR TITLE
Test for and fix implicit usage of native sized structs 

### DIFF
--- a/dpkt/dpkt.py
+++ b/dpkt/dpkt.py
@@ -36,13 +36,14 @@ class PackError(Error):
 class _MetaPacket(type):
     def __new__(cls, clsname, clsbases, clsdict):
         t = type.__new__(cls, clsname, clsbases, clsdict)
+        byte_order = getattr(t, '__byte_order__', '>')
         st = getattr(t, '__hdr__', None)
         if st is not None:
             # XXX - __slots__ only created in __new__()
             clsdict['__slots__'] = [x[0] for x in st] + ['data']
             t = type.__new__(cls, clsname, clsbases, clsdict)
             t.__hdr_fields__ = [x[0] for x in st]
-            t.__hdr_fmt__ = getattr(t, '__byte_order__', '>') + ''.join([x[1] for x in st])
+            t.__hdr_fmt__ = byte_order + ''.join([x[1] for x in st])
             t.__hdr_len__ = struct.calcsize(t.__hdr_fmt__)
             t.__hdr_defaults__ = dict(compat_izip(
                 t.__hdr_fields__, [x[2] for x in st]))
@@ -60,7 +61,8 @@ class _MetaPacket(type):
                     bits_used = 0
 
                     # make sure the sum of bits matches the overall size of the placeholder field
-                    assert bits_total == struct.calcsize(ph_struct) * 8, \
+                    # prepending ph_struct with byte_order implies standard size for the byte orders `=`, `<`, `>` and `!`
+                    assert bits_total == struct.calcsize('%s%s' % (byte_order, ph_struct)) * 8, \
                         "the overall count of bits in [%s] as declared in __bit_fields__ " \
                         "does not match its struct size in __hdr__" % ph_name
 

--- a/dpkt/dpkt.py
+++ b/dpkt/dpkt.py
@@ -474,6 +474,24 @@ def test_bit_fields_overflow():
         foo.a = 5
 
 
+def test_bit_field_size_is_calculated_using_standard_size():
+    class Foo(Packet):
+        __hdr__ = (
+            ("_a_b", "L", 0),
+        )
+
+        __bit_fields__ = {
+            "_a_b": (
+                ("a", 2*8),
+                ("b", 2*8),
+            ),
+        }
+
+        __byte_order__ = "<"
+
+    foo = Foo()
+
+
 def test_pack_hdr_tuple():
     """Test the unpacking of a tuple for a single format string"""
     class Foo(Packet):


### PR DESCRIPTION
The `struct.calcsize`[^1] in line 63 defaults to machine’s native format [^2], as long as not differently specified.

The data one parses should not yield different results based on the parsing machines architecture; which is acknowledged in

https://github.com/kbandla/dpkt/blob/2d30526422d48f83d4f724221d9ae0dcd5ff57fe/dpkt/dpkt.py#L45-L46

for `__hdr_fmt__` but is lacking for `__bit_fields__`.

resolves #644 

[^1]: https://docs.python.org/3/library/struct.html#struct.calcsize
[^2]: https://docs.python.org/3/library/struct.html#byte-order-size-and-alignment
