### PR TITLE
Add ieee80211 OUI, NACK and others

### DIFF
--- a/dpkt/ieee80211.py
+++ b/dpkt/ieee80211.py
@@ -557,8 +557,12 @@ class IEEE80211(dpkt.Packet):
             try:
                 decoder = action_parser[self.category][self.code][1]
                 field_name = action_parser[self.category][self.code][0]
+                self.decoded = True
+                self.error = None
             except KeyError:
-                raise dpkt.UnpackError("KeyError: category=%s code=%s" % (self.category, self.code))
+                self.decoded = False
+                self.error = dpkt.UnpackError("KeyError: category=%s code=%s" % (self.category, self.code))
+                return
 
             field = decoder(self.data)
             setattr(self, field_name, field)


### PR DESCRIPTION
Others are added simply by not throwing `ParseException` on parse failure. The user will at least get a packet with `type`,  `subtype `, and `data` and will be able to process the rest.

There is a support for MGMT Action vendor_specific that is used e.g. for Open Drone ID.