### PR TITLE
Added initial support for MACsec (#672)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,6 +8,9 @@ Dug Song <dugsong@monkey.org>
 Contributors
 ------------
 
+Philip Axer <philip@axonne.com>
+	MACsec support
+
 Timur Alperovich <timuralp@umich.edu>
 	radiotap module
 


### PR DESCRIPTION
This pull request implements intital support for MACsec. Worthwhile noting:
* MACsec decoding needs context which is not explict in the frames. The context must be provided to the Ethernet class via optional fields  macsec_ciphersuite and macsec_sak
* This also adresses #671. It would have been nicer to have a dedicated commit, but i havent had the time.