### PR TITLE
Add CoAP and LWM2M TLV support

### DIFF
--- a/dpkt/__init__.py
+++ b/dpkt/__init__.py
@@ -18,6 +18,7 @@ from . import arp
 from . import asn1
 from . import bgp
 from . import cdp
+from . import coap
 from . import dhcp
 from . import diameter
 from . import dns
@@ -39,6 +40,7 @@ from . import ip6
 from . import ipx
 from . import llc
 from . import loopback
+from . import lwm2m
 from . import mrt
 from . import netbios
 from . import netflow

--- a/dpkt/coap.py
+++ b/dpkt/coap.py
@@ -1,0 +1,314 @@
+# -*- coding: utf-8 -*-
+"""Constrained Application Protocol (CoAP)."""
+from __future__ import print_function
+from __future__ import absolute_import
+
+import struct
+from . import dpkt
+from .compat import compat_ord
+
+# CoAP Message Types (RFC 7252)
+COAP_CON = 0  # Confirmable
+COAP_NON = 1  # Non-confirmable
+COAP_ACK = 2  # Acknowledgement
+COAP_RST = 3  # Reset
+
+# CoAP Codes (RFC 7252)
+# Requests
+COAP_GET = 1
+COAP_POST = 2
+COAP_PUT = 3
+COAP_DELETE = 4
+
+# Responses
+COAP_CREATED = 65      # 2.01
+COAP_DELETED = 66      # 2.02
+COAP_VALID = 67        # 2.03
+COAP_CHANGED = 68      # 2.04
+COAP_CONTENT = 69      # 2.05
+COAP_BAD_REQUEST = 128 # 4.00
+COAP_UNAUTHORIZED = 129 # 4.01
+COAP_BAD_OPTION = 130   # 4.02
+COAP_FORBIDDEN = 131    # 4.03
+COAP_NOT_FOUND = 132    # 4.04
+COAP_METHOD_NOT_ALLOWED = 133 # 4.05
+COAP_NOT_ACCEPTABLE = 134     # 4.06
+COAP_PRECONDITION_FAILED = 140 # 4.12
+COAP_REQUEST_ENTITY_TOO_LARGE = 141 # 4.13
+COAP_UNSUPPORTED_CONTENT_FORMAT = 143 # 4.15
+COAP_INTERNAL_SERVER_ERROR = 160 # 5.00
+COAP_NOT_IMPLEMENTED = 161      # 5.01
+COAP_BAD_GATEWAY = 162          # 5.02
+COAP_SERVICE_UNAVAILABLE = 163  # 5.03
+COAP_GATEWAY_TIMEOUT = 164      # 5.04
+COAP_PROXYING_NOT_SUPPORTED = 165 # 5.05
+
+# CoAP Option Numbers (RFC 7252)
+COAP_OPT_IF_MATCH = 1
+COAP_OPT_URI_HOST = 3
+COAP_OPT_ETAG = 4
+COAP_OPT_IF_NONE_MATCH = 5
+COAP_OPT_OBSERVE = 6
+COAP_OPT_URI_PORT = 7
+COAP_OPT_LOCATION_PATH = 8
+COAP_OPT_URI_PATH = 11
+COAP_OPT_CONTENT_FORMAT = 12
+COAP_OPT_MAX_AGE = 14
+COAP_OPT_URI_QUERY = 15
+COAP_OPT_ACCEPT = 17
+COAP_OPT_LOCATION_QUERY = 20
+COAP_OPT_BLOCK2 = 23
+COAP_OPT_BLOCK1 = 27
+COAP_OPT_SIZE2 = 28
+COAP_OPT_PROXY_URI = 35
+COAP_OPT_PROXY_SCHEME = 39
+COAP_OPT_SIZE1 = 60
+
+# CoAP Content Formats (RFC 7252 and OMA LWM2M)
+COAP_FORMAT_TEXT = 0
+COAP_FORMAT_LINK = 40
+COAP_FORMAT_OCTET = 42
+COAP_FORMAT_EXI = 47
+COAP_FORMAT_XML = 48
+COAP_FORMAT_JSON = 50
+COAP_FORMAT_CBOR = 60
+COAP_FORMAT_LWM2M_TLV = 11542
+COAP_FORMAT_LWM2M_JSON = 11543
+COAP_FORMAT_SENML_JSON = 110
+COAP_FORMAT_SENML_CBOR = 112
+
+
+class CoAP(dpkt.Packet):
+    """Constrained Application Protocol.
+
+    The Constrained Application Protocol (CoAP) is a specialized web transfer protocol
+    for use with constrained nodes and constrained networks in the Internet of Things.
+    The protocol is designed for machine-to-machine (M2M) applications such as smart
+    energy and building automation.
+
+    RFC 7252
+
+    Attributes:
+        v (int): Version (2 bits). Default is 1.
+        t (int): Type (2 bits). 0=CON, 1=NON, 2=ACK, 3=RST.
+        tkl (int): Token Length (4 bits). 0-8 bytes.
+        code (int): Code (8 bits). Request or Response code.
+        id (int): Message ID (16 bits).
+        token (bytes): Token (0-8 bytes).
+        opts (list): List of (opt_num, value) tuples.
+    """
+
+    __hdr__ = (
+        ('_v_t_tkl', 'B', 0x40),  # Ver (2), T (2), TKL (4). Default Ver=1
+        ('code', 'B', 0),
+        ('id', 'H', 0),
+    )
+    __bit_fields__ = {
+        '_v_t_tkl': (
+            ('v', 2),
+            ('t', 2),
+            ('tkl', 4),
+        )
+    }
+
+    def __init__(self, *args, **kwargs):
+        self.token = b''
+        self.opts = []
+        super(CoAP, self).__init__(*args, **kwargs)
+
+    def unpack(self, buf):
+        dpkt.Packet.unpack(self, buf)
+        # Token
+        if self.tkl > 8:
+            raise dpkt.UnpackError('invalid token length: %d' % self.tkl)
+        if len(buf) < self.__hdr_len__ + self.tkl:
+            raise dpkt.NeedData('short token')
+        self.token = buf[self.__hdr_len__:self.__hdr_len__ + self.tkl]
+        off = self.__hdr_len__ + self.tkl
+
+        # Options
+        self.opts = []
+        last_opt_num = 0
+        while off < len(buf):
+            if compat_ord(buf[off]) == 0xFF:
+                if off + 1 == len(buf):
+                    raise dpkt.UnpackError('payload marker with no payload')
+                off += 1
+                break
+
+            # Read Option header
+            delta_len = compat_ord(buf[off])
+            off += 1
+            delta = (delta_len & 0xF0) >> 4
+            length = delta_len & 0x0F
+
+            if delta == 13:
+                if off >= len(buf):
+                    raise dpkt.NeedData('short option delta (1 byte)')
+                delta = compat_ord(buf[off]) + 13
+                off += 1
+            elif delta == 14:
+                if off + 2 > len(buf):
+                    raise dpkt.NeedData('short option delta (2 bytes)')
+                delta = struct.unpack('>H', buf[off:off + 2])[0] + 269
+                off += 2
+            elif delta == 15:
+                raise dpkt.UnpackError('invalid option delta: 15')
+
+            if length == 13:
+                if off >= len(buf):
+                    raise dpkt.NeedData('short option length (1 byte)')
+                length = compat_ord(buf[off]) + 13
+                off += 1
+            elif length == 14:
+                if off + 2 > len(buf):
+                    raise dpkt.NeedData('short option length (2 bytes)')
+                length = struct.unpack('>H', buf[off:off + 2])[0] + 269
+                off += 2
+            elif length == 15:
+                raise dpkt.UnpackError('invalid option length: 15')
+
+            if off + length > len(buf):
+                raise dpkt.NeedData('short option value')
+
+            opt_num = last_opt_num + delta
+            value = buf[off:off + length]
+            off += length
+
+            self.opts.append((opt_num, value))
+            last_opt_num = opt_num
+
+        self.data = buf[off:]
+
+    def _pack_opt(self, opt_num, value, last_opt_num):
+        delta = opt_num - last_opt_num
+        length = len(value)
+
+        res = b''
+
+        # Option Delta
+        if delta < 13:
+            d_val = delta
+        elif delta < 269:
+            d_val = 13
+        else:
+            d_val = 14
+
+        # Option Length
+        if length < 13:
+            l_val = length
+        elif length < 269:
+            l_val = 13
+        else:
+            l_val = 14
+
+        res += struct.pack('B', (d_val << 4) | l_val)
+
+        if d_val == 13:
+            res += struct.pack('B', delta - 13)
+        elif d_val == 14:
+            res += struct.pack('>H', delta - 269)
+
+        if l_val == 13:
+            res += struct.pack('B', length - 13)
+        elif l_val == 14:
+            res += struct.pack('>H', length - 269)
+
+        res += value
+        return res
+
+    def __len__(self):
+        opts_len = 0
+        last_opt_num = 0
+        for opt_num, value in sorted(self.opts):
+            opts_len += len(self._pack_opt(opt_num, value, last_opt_num))
+            last_opt_num = opt_num
+
+        return self.__hdr_len__ + len(self.token) + opts_len + (1 if self.data else 0) + len(self.data)
+
+    def __bytes__(self):
+        # Update TKL based on token length
+        self.tkl = len(self.token)
+
+        res = self.pack_hdr()
+        res += self.token
+
+        last_opt_num = 0
+        for opt_num, value in sorted(self.opts):
+            res += self._pack_opt(opt_num, value, last_opt_num)
+            last_opt_num = opt_num
+
+        if self.data:
+            res += b'\xff'
+            res += bytes(self.data)
+
+        return res
+
+    @property
+    def code_class(self):
+        return self.code >> 5
+
+    @property
+    def code_detail(self):
+        return self.code & 0x1F
+
+
+def test_coap():
+    from binascii import unhexlify
+    # Example from RFC 7252: GET /test (CON, MID=0x7d34)
+    # 0x40 (Ver=1, T=CON, TKL=0)
+    # 0x01 (Code=GET)
+    # 0x7d34 (MID)
+    # 0xb4 (Delta=11 (Uri-Path), Length=4)
+    # 0x74657374 ("test")
+    buf = unhexlify('40017d34b474657374')
+    c = CoAP(buf)
+    assert c.v == 1
+    assert c.t == COAP_CON
+    assert c.tkl == 0
+    assert c.code == COAP_GET
+    assert c.id == 0x7d34
+    assert len(c.opts) == 1
+    assert c.opts[0] == (COAP_OPT_URI_PATH, b'test')
+    assert bytes(c) == buf
+
+    # Example with token and payload
+    # 0x42 (Ver=1, T=CON, TKL=2)
+    # 0x01 (Code=GET)
+    # 0x1234 (MID)
+    # 0xabcd (Token)
+    # 0xff (Payload Marker)
+    # 0x68656c6c6f ("hello")
+    buf2 = unhexlify('42011234abcdff68656c6c6f')
+    c2 = CoAP(buf2)
+    assert c2.tkl == 2
+    assert c2.token == b'\xab\xcd'
+    assert c2.data == b'hello'
+    assert bytes(c2) == buf2
+
+    # Example with multiple options
+    c3 = CoAP(t=COAP_NON, code=COAP_POST, id=0xabcd)
+    c3.opts = [(COAP_OPT_URI_HOST, b'example.com'), (COAP_OPT_URI_PATH, b'test')]
+    c3.data = b'payload'
+    buf3 = bytes(c3)
+    c3_parsed = CoAP(buf3)
+    assert c3_parsed.t == COAP_NON
+    assert c3_parsed.code == COAP_POST
+    assert c3_parsed.id == 0xabcd
+    assert len(c3_parsed.opts) == 2
+    assert c3_parsed.opts[0] == (COAP_OPT_URI_HOST, b'example.com')
+    assert c3_parsed.opts[1] == (COAP_OPT_URI_PATH, b'test')
+    assert c3_parsed.data == b'payload'
+
+    # Test payload marker with no payload (RFC 7252 Section 3)
+    buf4 = unhexlify('40017d34ff')
+    try:
+        CoAP(buf4)
+        assert False, "Should have raised UnpackError"
+    except dpkt.UnpackError as e:
+        assert str(e) == 'payload marker with no payload'
+
+
+if __name__ == '__main__':
+    test_coap()
+    print('Tests passed.')

--- a/dpkt/lwm2m.py
+++ b/dpkt/lwm2m.py
@@ -36,153 +36,345 @@ LWM2M_DEV_UTC_OFFSET = 14
 LWM2M_DEV_TIMEZONE = 15
 LWM2M_DEV_SUPPORTED_BINDING = 16
 
-# LWM2M TLV Type IDs
-LWM2M_TLV_OBJECT_INSTANCE = 0x00  # 00
-LWM2M_TLV_RESOURCE_INSTANCE = 0x40  # 01
-LWM2M_TLV_MULTIPLE_RESOURCE = 0x80  # 10
-LWM2M_TLV_RESOURCE = 0xC0  # 11
+# TLV Type IDs (top two bits of the TLV type byte)
+LWM2M_TLV_OBJECT_INSTANCE = 0x00     # 00
+LWM2M_TLV_RESOURCE_INSTANCE = 0x40   # 01
+LWM2M_TLV_MULTIPLE_RESOURCE = 0x80   # 10
+LWM2M_TLV_RESOURCE = 0xC0            # 11
 
 
-class LWM2M_TLV(dpkt.Packet):
-    """LWM2M Binary TLV Format.
+class LWM2M(object):
+    """LWM2M Protocol namespace (OMA Lightweight M2M).
 
-    OMA LWM2M v1.0, Section 6.3.3.
+    LwM2M payloads ride inside CoAP, so this class is a logical
+    namespace rather than a wire-level packet. It groups:
 
-    Attributes:
-        type (int): TLV Type (Object Instance, Resource, etc.)
-        id (int): Identifier (8 or 16 bits)
-        value (bytes): Value
+    * an abstract data model — :class:`LWM2M.Resource`,
+      :class:`LWM2M.ObjectInstance`
+    * supported wire formats — :class:`LWM2M.TLV` (more to come)
+    * format dispatch — :meth:`LWM2M.encode`, :meth:`LWM2M.decode`
+
+    The data model lets callers construct an LwM2M payload once and
+    serialize it to whichever format the peer asked for, and decode any
+    incoming payload back to the same uniform shape.
     """
 
-    def __init__(self, *args, **kwargs):
-        self.type = 0
-        self.id = 0
-        self.value = b''
-        super(LWM2M_TLV, self).__init__(*args, **kwargs)
+    # ---------------------------------------------------------------- formats
 
-    def unpack(self, buf):
-        if not buf:
-            raise dpkt.NeedData('empty TLV')
-        
-        # Type byte
-        type_byte = compat_ord(buf[0])
-        self.type = type_byte & 0xC0  # bits 7-6
-        id_len = (type_byte & 0x20) >> 5  # bit 5: 0=8bit, 1=16bit
-        length_type = (type_byte & 0x18) >> 3  # bits 4-3: 00=no length, 01=8bit, 10=16bit, 11=24bit
-        val_len = type_byte & 0x07  # bits 2-0: value length if length_type=00
-        
-        off = 1
-        
-        # Identifier
-        if id_len == 0:
-            if off >= len(buf): raise dpkt.NeedData()
-            self.id = compat_ord(buf[off])
-            off += 1
-        else:
-            if off + 2 > len(buf): raise dpkt.NeedData()
-            self.id = struct.unpack('>H', buf[off:off+2])[0]
-            off += 2
-            
-        # Length
-        if length_type == 1: # 8-bit length
-            if off >= len(buf): raise dpkt.NeedData()
-            val_len = compat_ord(buf[off])
-            off += 1
-        elif length_type == 2: # 16-bit length
-            if off + 2 > len(buf): raise dpkt.NeedData()
-            val_len = struct.unpack('>H', buf[off:off+2])[0]
-            off += 2
-        elif length_type == 3: # 24-bit length
-            if off + 3 > len(buf): raise dpkt.NeedData()
-            val_len = struct.unpack('>I', b'\x00' + buf[off:off+3])[0]
-            off += 3
-        # if length_type == 0, val_len is already set from bits 2-0
-            
-        if off + val_len > len(buf):
-            raise dpkt.NeedData('short TLV value')
-            
-        self.value = buf[off:off+val_len]
-        self.data = buf[off+val_len:]
+    class ContentFormat(object):
+        """CoAP Content-Format option values for LWM2M payloads."""
+        TEXT = 0
+        OPAQUE = 42
+        TLV = 11542
+        JSON = 11543
+        SENML_JSON = 110
+        SENML_CBOR = 112
+        LWM2M_CBOR = 11544
 
-    def __bytes__(self):
-        # Determine Identifier length bit
-        id_bit = 0x20 if self.id > 255 else 0x00
-        
-        # Determine Length type and value
-        val_len = len(self.value)
-        if val_len < 8:
-            len_type = 0x00
-            len_bits = val_len
-            len_field = b''
-        elif val_len < 256:
-            len_type = 0x08 # 01
-            len_bits = 0
-            len_field = struct.pack('B', val_len)
-        elif val_len < 65536:
-            len_type = 0x10 # 10
-            len_bits = 0
-            len_field = struct.pack('>H', val_len)
-        else:
-            len_type = 0x18 # 11
-            len_bits = 0
-            len_field = struct.pack('>I', val_len)[1:] # 24-bit
+    # ---------------------------------------------------------- data model
 
-        type_byte = self.type | id_bit | len_type | len_bits
-        res = struct.pack('B', type_byte)
-        
-        if id_bit:
-            res += struct.pack('>H', self.id)
-        else:
-            res += struct.pack('B', self.id)
-            
-        res += len_field
-        res += self.value
-        return res
+    class Resource(object):
+        """LwM2M Resource — a single value or a multi-instance value-set.
 
-    def __len__(self):
-        return len(bytes(self))
+        For a single-instance Resource, set ``value`` and leave
+        ``instances`` as ``None``. For a multi-instance Resource, set
+        ``instances`` to a dict mapping ``instance_id`` → value.
+        """
+
+        def __init__(self, id, value=None, instances=None):
+            self.id = id
+            self.value = value
+            self.instances = instances
+
+        @property
+        def is_multi(self):
+            return self.instances is not None
+
+        def __repr__(self):
+            if self.is_multi:
+                return 'Resource(id=%d, instances=%r)' % (self.id, self.instances)
+            return 'Resource(id=%d, value=%r)' % (self.id, self.value)
+
+        def __eq__(self, other):
+            return (isinstance(other, LWM2M.Resource)
+                    and self.id == other.id
+                    and self.value == other.value
+                    and self.instances == other.instances)
+
+    class ObjectInstance(object):
+        """LwM2M Object Instance — an ordered set of Resources."""
+
+        def __init__(self, id=0, resources=None):
+            self.id = id
+            self.resources = list(resources or [])
+
+        def __repr__(self):
+            return 'ObjectInstance(id=%d, resources=%r)' % (self.id, self.resources)
+
+        def __eq__(self, other):
+            return (isinstance(other, LWM2M.ObjectInstance)
+                    and self.id == other.id
+                    and self.resources == other.resources)
+
+    # --------------------------------------------------------- wire formats
+
+    class TLV(dpkt.Packet):
+        """LWM2M Binary TLV Format. OMA LwM2M v1.0, Section 6.3.3.
+
+        Attributes:
+            type (int): TLV Type (Object Instance, Resource, etc.)
+            id (int): Identifier (8 or 16 bits)
+            value (bytes): Value
+        """
+
+        def __init__(self, *args, **kwargs):
+            self.type = 0
+            self.id = 0
+            self.value = b''
+            super(LWM2M.TLV, self).__init__(*args, **kwargs)
+
+        def unpack(self, buf):
+            if not buf:
+                raise dpkt.NeedData('empty TLV')
+
+            type_byte = compat_ord(buf[0])
+            self.type = type_byte & 0xC0  # bits 7-6
+            id_len = (type_byte & 0x20) >> 5  # bit 5: 0=8bit, 1=16bit
+            length_type = (type_byte & 0x18) >> 3  # bits 4-3
+            val_len = type_byte & 0x07  # bits 2-0: value length if length_type=00
+
+            off = 1
+
+            if id_len == 0:
+                if off >= len(buf): raise dpkt.NeedData()
+                self.id = compat_ord(buf[off])
+                off += 1
+            else:
+                if off + 2 > len(buf): raise dpkt.NeedData()
+                self.id = struct.unpack('>H', buf[off:off+2])[0]
+                off += 2
+
+            if length_type == 1:
+                if off >= len(buf): raise dpkt.NeedData()
+                val_len = compat_ord(buf[off])
+                off += 1
+            elif length_type == 2:
+                if off + 2 > len(buf): raise dpkt.NeedData()
+                val_len = struct.unpack('>H', buf[off:off+2])[0]
+                off += 2
+            elif length_type == 3:
+                if off + 3 > len(buf): raise dpkt.NeedData()
+                val_len = struct.unpack('>I', b'\x00' + buf[off:off+3])[0]
+                off += 3
+
+            if off + val_len > len(buf):
+                raise dpkt.NeedData('short TLV value')
+
+            self.value = buf[off:off+val_len]
+            self.data = buf[off+val_len:]
+
+        def __bytes__(self):
+            id_bit = 0x20 if self.id > 255 else 0x00
+
+            val_len = len(self.value)
+            if val_len < 8:
+                len_type = 0x00
+                len_bits = val_len
+                len_field = b''
+            elif val_len < 256:
+                len_type = 0x08
+                len_bits = 0
+                len_field = struct.pack('B', val_len)
+            elif val_len < 65536:
+                len_type = 0x10
+                len_bits = 0
+                len_field = struct.pack('>H', val_len)
+            else:
+                len_type = 0x18
+                len_bits = 0
+                len_field = struct.pack('>I', val_len)[1:]
+
+            type_byte = self.type | id_bit | len_type | len_bits
+            res = struct.pack('B', type_byte)
+
+            if id_bit:
+                res += struct.pack('>H', self.id)
+            else:
+                res += struct.pack('B', self.id)
+
+            res += len_field
+            res += self.value
+            return res
+
+        def __len__(self):
+            return len(bytes(self))
+
+    # ---------------------------------------------------------- dispatch
+
+    @staticmethod
+    def encode(obj, content_format, base_path=''):
+        """Encode a Resource / ObjectInstance / list to wire bytes.
+
+        ``base_path`` is reserved for self-describing formats and is
+        ignored by the TLV codec. Only :data:`LWM2M.ContentFormat.TLV`
+        is implemented today.
+        """
+        if content_format == LWM2M.ContentFormat.TLV:
+            return _encode_tlv(obj)
+        raise NotImplementedError(
+            'LWM2M content format %r is not implemented' % content_format)
+
+    @staticmethod
+    def decode(buf, content_format, base_path=''):
+        """Decode wire bytes to data-model objects.
+
+        Returns a single :class:`LWM2M.ObjectInstance` or
+        :class:`LWM2M.Resource` when the payload describes one;
+        otherwise a list. For TLV, decoded ``Resource.value`` fields
+        are raw ``bytes`` (TLV is not self-describing — apply your
+        Object schema to interpret them).
+        """
+        if content_format == LWM2M.ContentFormat.TLV:
+            return _decode_tlv(buf)
+        raise NotImplementedError(
+            'LWM2M content format %r is not implemented' % content_format)
 
 
-def parse_tlvs(buf):
-    """Parse a buffer containing multiple LWM2M TLVs."""
-    tlvs = []
+# ============================================================ TLV codec
+
+def _encode_tlv_value(v):
+    """Encode a Python value into the bytes of a TLV value field."""
+    if isinstance(v, bytes):
+        return v
+    if isinstance(v, bool):  # check before int — bool is a subclass of int
+        return b'\x01' if v else b'\x00'
+    if isinstance(v, int):
+        if -128 <= v <= 127:
+            return struct.pack('>b', v)
+        if -32768 <= v <= 32767:
+            return struct.pack('>h', v)
+        if -2147483648 <= v <= 2147483647:
+            return struct.pack('>i', v)
+        return struct.pack('>q', v)
+    if isinstance(v, float):
+        return struct.pack('>d', v)
+    if isinstance(v, str):
+        return v.encode('utf-8')
+    raise TypeError('cannot encode TLV value of type %s' % type(v).__name__)
+
+
+def _resource_to_tlv(res):
+    if res.is_multi:
+        body = b''
+        for inst_id in sorted(res.instances):
+            inner = LWM2M.TLV(type=LWM2M_TLV_RESOURCE_INSTANCE,
+                              id=inst_id,
+                              value=_encode_tlv_value(res.instances[inst_id]))
+            body += bytes(inner)
+        return LWM2M.TLV(type=LWM2M_TLV_MULTIPLE_RESOURCE, id=res.id, value=body)
+    return LWM2M.TLV(type=LWM2M_TLV_RESOURCE, id=res.id,
+                     value=_encode_tlv_value(res.value))
+
+
+def _encode_tlv(obj):
+    if isinstance(obj, LWM2M.Resource):
+        return bytes(_resource_to_tlv(obj))
+    if isinstance(obj, LWM2M.ObjectInstance):
+        body = b''.join(bytes(_resource_to_tlv(r)) for r in obj.resources)
+        return bytes(LWM2M.TLV(type=LWM2M_TLV_OBJECT_INSTANCE, id=obj.id, value=body))
+    if isinstance(obj, (list, tuple)):
+        return b''.join(_encode_tlv(item) for item in obj)
+    raise TypeError('cannot encode %s as TLV' % type(obj).__name__)
+
+
+def _tlv_to_model(tlv):
+    if tlv.type == LWM2M_TLV_RESOURCE:
+        return LWM2M.Resource(id=tlv.id, value=tlv.value)
+    if tlv.type == LWM2M_TLV_RESOURCE_INSTANCE:
+        return LWM2M.Resource(id=tlv.id, value=tlv.value)
+    if tlv.type == LWM2M_TLV_MULTIPLE_RESOURCE:
+        instances = {}
+        buf = tlv.value
+        while buf:
+            inner = LWM2M.TLV(buf)
+            instances[inner.id] = inner.value
+            buf = inner.data
+        return LWM2M.Resource(id=tlv.id, instances=instances)
+    if tlv.type == LWM2M_TLV_OBJECT_INSTANCE:
+        children = []
+        buf = tlv.value
+        while buf:
+            child = LWM2M.TLV(buf)
+            children.append(_tlv_to_model(child))
+            buf = child.data
+        return LWM2M.ObjectInstance(id=tlv.id, resources=children)
+    raise ValueError('unknown TLV type 0x%02x' % tlv.type)
+
+
+def _decode_tlv(buf):
+    items = []
     while buf:
-        tlv = LWM2M_TLV(buf)
-        tlvs.append(tlv)
+        tlv = LWM2M.TLV(buf)
+        items.append(_tlv_to_model(tlv))
         buf = tlv.data
-    return tlvs
+    if len(items) == 1:
+        return items[0]
+    return items
 
+
+# ================================================================ tests
 
 def test_lwm2m():
     from binascii import unhexlify
-    # Example from OMA spec: Resource 5850 (Switch) with value 1 (True)
-    # Type: 11 (Resource), ID length 1 (16-bit), Length type 00, Length 1
-    # 0xC0 | 0x20 | 0x00 | 0x01 = 0xE1
-    # ID: 5850 = 0x16da
-    # Value: 0x01
+    CF = LWM2M.ContentFormat
+
+    # ---- TLV: low-level wire round-trip ------------------------------
+    # OMA spec example: Resource 5850 (Switch) = True (0x01)
     buf = unhexlify('e116da01')
-    tlv = LWM2M_TLV(buf)
+    tlv = LWM2M.TLV(buf)
     assert tlv.type == LWM2M_TLV_RESOURCE
     assert tlv.id == 5850
     assert tlv.value == b'\x01'
     assert bytes(tlv) == buf
 
-    # Multiple resources example
     # Resource 0 (Manufacturer): "Open Mobile Alliance"
-    # Type: 11, ID len 0 (8-bit), Len type 01 (8-bit), Val len 20
-    # 0xC0 | 0x00 | 0x08 | 0x00 = 0xC8
     buf2 = unhexlify('c800144f70656e204d6f62696c6520416c6c69616e6365')
-    tlv2 = LWM2M_TLV(buf2)
+    tlv2 = LWM2M.TLV(buf2)
     assert tlv2.id == 0
     assert tlv2.value == b'Open Mobile Alliance'
     assert bytes(tlv2) == buf2
 
-    # Test parse_tlvs
-    combined = buf + buf2
-    tlvs = parse_tlvs(combined)
-    assert len(tlvs) == 2
-    assert tlvs[0].id == 5850
-    assert tlvs[1].id == 0
+    # ---- Data model + TLV codec --------------------------------------
+    inst = LWM2M.ObjectInstance(id=0, resources=[
+        LWM2M.Resource(id=LWM2M_DEV_MANUFACTURER, value='Open Mobile Alliance'),
+        LWM2M.Resource(id=LWM2M_DEV_BATTERY_LEVEL, value=100),
+        LWM2M.Resource(id=LWM2M_DEV_AVAILABLE_POWER_SOURCES,
+                       instances={0: 1, 1: 5}),
+    ])
+    tlv_bytes = LWM2M.encode(inst, CF.TLV)
+    decoded = LWM2M.decode(tlv_bytes, CF.TLV)
+    assert isinstance(decoded, LWM2M.ObjectInstance)
+    assert decoded.id == 0
+    assert len(decoded.resources) == 3
+    # TLV decode returns raw bytes for values (no schema).
+    assert decoded.resources[0].value == b'Open Mobile Alliance'
+    # The multi-instance resource came back as a multi-instance Resource.
+    multi = decoded.resources[2]
+    assert multi.is_multi
+    assert set(multi.instances.keys()) == {0, 1}
+
+    # ---- Direct Resource + bare-list paths ---------------------------
+    single = LWM2M.Resource(id=5850, value=True)
+    rt = LWM2M.decode(LWM2M.encode(single, CF.TLV), CF.TLV)
+    assert isinstance(rt, LWM2M.Resource) and rt.id == 5850
+
+    # ---- Unimplemented format ----------------------------------------
+    try:
+        LWM2M.decode(b'', CF.JSON)
+    except NotImplementedError:
+        pass
+    else:
+        raise AssertionError('expected NotImplementedError')
 
 
 if __name__ == '__main__':

--- a/dpkt/lwm2m.py
+++ b/dpkt/lwm2m.py
@@ -3,6 +3,8 @@
 from __future__ import print_function
 from __future__ import absolute_import
 
+import base64 as _base64
+import json as _json
 import struct
 from . import dpkt
 from .compat import compat_ord
@@ -51,7 +53,7 @@ class LWM2M(object):
 
     * an abstract data model — :class:`LWM2M.Resource`,
       :class:`LWM2M.ObjectInstance`
-    * supported wire formats — :class:`LWM2M.TLV` (more to come)
+    * supported wire formats — :class:`LWM2M.TLV`, :class:`LWM2M.JSON`
     * format dispatch — :meth:`LWM2M.encode`, :meth:`LWM2M.decode`
 
     The data model lets callers construct an LwM2M payload once and
@@ -209,18 +211,63 @@ class LWM2M(object):
         def __len__(self):
             return len(bytes(self))
 
+    class JSON(dpkt.Packet):
+        """LWM2M JSON Format. OMA LwM2M v1.0, Section 6.3.4.
+
+        Wire form is a single JSON object::
+
+            {"bn": "/3/0/", "e": [{"n": "0", "sv": "Open Mobile Alliance"},
+                                  {"n": "9", "v": 100}]}
+
+        Attributes:
+            bn (str): Base Name — URI prefix prepended to each entry's ``n``.
+            bt (int|None): Base Time (Unix seconds), or ``None`` if absent.
+            entries (list[dict]): Entry dicts, each with ``n`` plus exactly
+                one of ``sv`` (string), ``v`` (number), ``bv`` (bool),
+                ``ov`` (object link); plus optional ``t`` (time).
+        """
+
+        def __init__(self, *args, **kwargs):
+            self.bn = ''
+            self.bt = None
+            self.entries = []
+            super(LWM2M.JSON, self).__init__(*args, **kwargs)
+
+        def unpack(self, buf):
+            if isinstance(buf, bytes):
+                buf = buf.decode('utf-8')
+            obj = _json.loads(buf)
+            self.bn = obj.get('bn', '')
+            self.bt = obj.get('bt')
+            self.entries = obj.get('e', [])
+            self.data = b''
+
+        def __bytes__(self):
+            out = {}
+            if self.bn:
+                out['bn'] = self.bn
+            if self.bt is not None:
+                out['bt'] = self.bt
+            out['e'] = self.entries
+            return _json.dumps(out, separators=(',', ':')).encode('utf-8')
+
+        def __len__(self):
+            return len(bytes(self))
+
     # ---------------------------------------------------------- dispatch
 
     @staticmethod
     def encode(obj, content_format, base_path=''):
         """Encode a Resource / ObjectInstance / list to wire bytes.
 
-        ``base_path`` is reserved for self-describing formats and is
-        ignored by the TLV codec. Only :data:`LWM2M.ContentFormat.TLV`
-        is implemented today.
+        ``base_path`` is only used by JSON and becomes the ``bn`` field.
+        Conventionally something like ``"/3/0/"`` for a Device Object
+        Instance read.
         """
         if content_format == LWM2M.ContentFormat.TLV:
             return _encode_tlv(obj)
+        if content_format == LWM2M.ContentFormat.JSON:
+            return _encode_json(obj, base_path)
         raise NotImplementedError(
             'LWM2M content format %r is not implemented' % content_format)
 
@@ -232,10 +279,13 @@ class LWM2M(object):
         :class:`LWM2M.Resource` when the payload describes one;
         otherwise a list. For TLV, decoded ``Resource.value`` fields
         are raw ``bytes`` (TLV is not self-describing — apply your
-        Object schema to interpret them).
+        Object schema to interpret them). JSON decodes preserve native
+        Python types from the wire.
         """
         if content_format == LWM2M.ContentFormat.TLV:
             return _decode_tlv(buf)
+        if content_format == LWM2M.ContentFormat.JSON:
+            return _decode_json(buf, base_path)
         raise NotImplementedError(
             'LWM2M content format %r is not implemented' % content_format)
 
@@ -322,6 +372,88 @@ def _decode_tlv(buf):
     return items
 
 
+# =========================================================== JSON codec
+
+def _entry_for_value(name, value):
+    e = {'n': name}
+    if isinstance(value, bool):  # before int
+        e['bv'] = value
+    elif isinstance(value, (int, float)):
+        e['v'] = value
+    elif isinstance(value, str):
+        e['sv'] = value
+    elif isinstance(value, bytes):
+        e['sv'] = _base64.b64encode(value).decode('ascii')
+    else:
+        raise TypeError('cannot encode JSON value of type %s' % type(value).__name__)
+    return e
+
+
+def _value_from_entry(entry):
+    for key in ('sv', 'v', 'bv', 'ov'):
+        if key in entry:
+            return entry[key]
+    return None
+
+
+def _json_entries_for(obj, prefix=''):
+    """Yield JSON entry dicts describing ``obj``. Names are relative
+    to whatever ``base_path`` (``bn``) the caller will set."""
+    if isinstance(obj, LWM2M.Resource):
+        if obj.is_multi:
+            for inst_id in sorted(obj.instances):
+                yield _entry_for_value('%s%d/%d' % (prefix, obj.id, inst_id),
+                                       obj.instances[inst_id])
+        else:
+            yield _entry_for_value('%s%d' % (prefix, obj.id), obj.value)
+    elif isinstance(obj, LWM2M.ObjectInstance):
+        for r in obj.resources:
+            for e in _json_entries_for(r, prefix):
+                yield e
+    elif isinstance(obj, (list, tuple)):
+        for item in obj:
+            for e in _json_entries_for(item, prefix):
+                yield e
+    else:
+        raise TypeError('cannot encode %s as JSON' % type(obj).__name__)
+
+
+def _encode_json(obj, base_path):
+    j = LWM2M.JSON(bn=base_path, entries=list(_json_entries_for(obj)))
+    return bytes(j)
+
+
+def _decode_json(buf, base_path):
+    j = LWM2M.JSON(buf)
+    by_res = {}
+    for e in j.entries:
+        parts = e['n'].split('/')
+        if len(parts) == 1:
+            res_id = int(parts[0])
+            by_res[res_id] = LWM2M.Resource(id=res_id, value=_value_from_entry(e))
+        elif len(parts) == 2:
+            res_id, inst_id = int(parts[0]), int(parts[1])
+            r = by_res.get(res_id)
+            if r is None or not r.is_multi:
+                r = LWM2M.Resource(id=res_id, instances={})
+                by_res[res_id] = r
+            r.instances[inst_id] = _value_from_entry(e)
+        else:
+            raise ValueError('unexpected JSON entry name %r' % e['n'])
+
+    resources = [by_res[rid] for rid in sorted(by_res)]
+
+    # If bn (or fallback base_path) names an object instance "/<obj>/<inst>/",
+    # wrap as an ObjectInstance; otherwise hand back the bare Resource list.
+    bp = j.bn or base_path
+    bp_parts = [p for p in bp.split('/') if p]
+    if len(bp_parts) >= 2:
+        return LWM2M.ObjectInstance(id=int(bp_parts[1]), resources=resources)
+    if len(resources) == 1:
+        return resources[0]
+    return resources
+
+
 # ================================================================ tests
 
 def test_lwm2m():
@@ -363,6 +495,29 @@ def test_lwm2m():
     assert multi.is_multi
     assert set(multi.instances.keys()) == {0, 1}
 
+    # ---- JSON codec --------------------------------------------------
+    json_bytes = LWM2M.encode(inst, CF.JSON, base_path='/3/0/')
+    j = LWM2M.JSON(json_bytes)
+    assert j.bn == '/3/0/'
+    # Three resources, but the multi-instance one expands to 2 entries → 4.
+    assert len(j.entries) == 4
+    assert {e['n'] for e in j.entries} == {'0', '9', '6/0', '6/1'}
+
+    # JSON round-trip: decode → re-encode preserves values (native types).
+    decoded_j = LWM2M.decode(json_bytes, CF.JSON)
+    assert isinstance(decoded_j, LWM2M.ObjectInstance)
+    assert decoded_j.id == 0
+    by_id = {r.id: r for r in decoded_j.resources}
+    assert by_id[LWM2M_DEV_MANUFACTURER].value == 'Open Mobile Alliance'
+    assert by_id[LWM2M_DEV_BATTERY_LEVEL].value == 100
+    assert by_id[LWM2M_DEV_AVAILABLE_POWER_SOURCES].instances == {0: 1, 1: 5}
+
+    # JSON wire matches the OMA-style human-readable form.
+    parsed = _json.loads(json_bytes.decode())
+    assert parsed['bn'] == '/3/0/'
+    assert {'n': '0', 'sv': 'Open Mobile Alliance'} in parsed['e']
+    assert {'n': '9', 'v': 100} in parsed['e']
+
     # ---- Direct Resource + bare-list paths ---------------------------
     single = LWM2M.Resource(id=5850, value=True)
     rt = LWM2M.decode(LWM2M.encode(single, CF.TLV), CF.TLV)
@@ -370,7 +525,7 @@ def test_lwm2m():
 
     # ---- Unimplemented format ----------------------------------------
     try:
-        LWM2M.decode(b'', CF.JSON)
+        LWM2M.decode(b'', CF.SENML_CBOR)
     except NotImplementedError:
         pass
     else:

--- a/dpkt/lwm2m.py
+++ b/dpkt/lwm2m.py
@@ -1,0 +1,190 @@
+# -*- coding: utf-8 -*-
+"""Lightweight Machine to Machine (LWM2M) Protocol."""
+from __future__ import print_function
+from __future__ import absolute_import
+
+import struct
+from . import dpkt
+from .compat import compat_ord
+
+# LWM2M Standard Object IDs (OMA)
+LWM2M_OBJ_SECURITY = 0
+LWM2M_OBJ_SERVER = 1
+LWM2M_OBJ_ACCESS_CONTROL = 2
+LWM2M_OBJ_DEVICE = 3
+LWM2M_OBJ_CONN_MONITOR = 4
+LWM2M_OBJ_FIRMWARE_UPDATE = 5
+LWM2M_OBJ_LOCATION = 6
+LWM2M_OBJ_CONN_STATS = 7
+
+# LWM2M Device Object Resources (Object ID 3)
+LWM2M_DEV_MANUFACTURER = 0
+LWM2M_DEV_MODEL_NUMBER = 1
+LWM2M_DEV_SERIAL_NUMBER = 2
+LWM2M_DEV_FIRMWARE_VERSION = 3
+LWM2M_DEV_REBOOT = 4
+LWM2M_DEV_FACTORY_RESET = 5
+LWM2M_DEV_AVAILABLE_POWER_SOURCES = 6
+LWM2M_DEV_POWER_SOURCE_VOLTAGE = 7
+LWM2M_DEV_POWER_SOURCE_CURRENT = 8
+LWM2M_DEV_BATTERY_LEVEL = 9
+LWM2M_DEV_MEMORY_FREE = 10
+LWM2M_DEV_ERROR_CODE = 11
+LWM2M_DEV_RESET_ERROR_CODE = 12
+LWM2M_DEV_CURRENT_TIME = 13
+LWM2M_DEV_UTC_OFFSET = 14
+LWM2M_DEV_TIMEZONE = 15
+LWM2M_DEV_SUPPORTED_BINDING = 16
+
+# LWM2M TLV Type IDs
+LWM2M_TLV_OBJECT_INSTANCE = 0x00  # 00
+LWM2M_TLV_RESOURCE_INSTANCE = 0x40  # 01
+LWM2M_TLV_MULTIPLE_RESOURCE = 0x80  # 10
+LWM2M_TLV_RESOURCE = 0xC0  # 11
+
+
+class LWM2M_TLV(dpkt.Packet):
+    """LWM2M Binary TLV Format.
+
+    OMA LWM2M v1.0, Section 6.3.3.
+
+    Attributes:
+        type (int): TLV Type (Object Instance, Resource, etc.)
+        id (int): Identifier (8 or 16 bits)
+        value (bytes): Value
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.type = 0
+        self.id = 0
+        self.value = b''
+        super(LWM2M_TLV, self).__init__(*args, **kwargs)
+
+    def unpack(self, buf):
+        if not buf:
+            raise dpkt.NeedData('empty TLV')
+        
+        # Type byte
+        type_byte = compat_ord(buf[0])
+        self.type = type_byte & 0xC0  # bits 7-6
+        id_len = (type_byte & 0x20) >> 5  # bit 5: 0=8bit, 1=16bit
+        length_type = (type_byte & 0x18) >> 3  # bits 4-3: 00=no length, 01=8bit, 10=16bit, 11=24bit
+        val_len = type_byte & 0x07  # bits 2-0: value length if length_type=00
+        
+        off = 1
+        
+        # Identifier
+        if id_len == 0:
+            if off >= len(buf): raise dpkt.NeedData()
+            self.id = compat_ord(buf[off])
+            off += 1
+        else:
+            if off + 2 > len(buf): raise dpkt.NeedData()
+            self.id = struct.unpack('>H', buf[off:off+2])[0]
+            off += 2
+            
+        # Length
+        if length_type == 1: # 8-bit length
+            if off >= len(buf): raise dpkt.NeedData()
+            val_len = compat_ord(buf[off])
+            off += 1
+        elif length_type == 2: # 16-bit length
+            if off + 2 > len(buf): raise dpkt.NeedData()
+            val_len = struct.unpack('>H', buf[off:off+2])[0]
+            off += 2
+        elif length_type == 3: # 24-bit length
+            if off + 3 > len(buf): raise dpkt.NeedData()
+            val_len = struct.unpack('>I', b'\x00' + buf[off:off+3])[0]
+            off += 3
+        # if length_type == 0, val_len is already set from bits 2-0
+            
+        if off + val_len > len(buf):
+            raise dpkt.NeedData('short TLV value')
+            
+        self.value = buf[off:off+val_len]
+        self.data = buf[off+val_len:]
+
+    def __bytes__(self):
+        # Determine Identifier length bit
+        id_bit = 0x20 if self.id > 255 else 0x00
+        
+        # Determine Length type and value
+        val_len = len(self.value)
+        if val_len < 8:
+            len_type = 0x00
+            len_bits = val_len
+            len_field = b''
+        elif val_len < 256:
+            len_type = 0x08 # 01
+            len_bits = 0
+            len_field = struct.pack('B', val_len)
+        elif val_len < 65536:
+            len_type = 0x10 # 10
+            len_bits = 0
+            len_field = struct.pack('>H', val_len)
+        else:
+            len_type = 0x18 # 11
+            len_bits = 0
+            len_field = struct.pack('>I', val_len)[1:] # 24-bit
+
+        type_byte = self.type | id_bit | len_type | len_bits
+        res = struct.pack('B', type_byte)
+        
+        if id_bit:
+            res += struct.pack('>H', self.id)
+        else:
+            res += struct.pack('B', self.id)
+            
+        res += len_field
+        res += self.value
+        return res
+
+    def __len__(self):
+        return len(bytes(self))
+
+
+def parse_tlvs(buf):
+    """Parse a buffer containing multiple LWM2M TLVs."""
+    tlvs = []
+    while buf:
+        tlv = LWM2M_TLV(buf)
+        tlvs.append(tlv)
+        buf = tlv.data
+    return tlvs
+
+
+def test_lwm2m():
+    from binascii import unhexlify
+    # Example from OMA spec: Resource 5850 (Switch) with value 1 (True)
+    # Type: 11 (Resource), ID length 1 (16-bit), Length type 00, Length 1
+    # 0xC0 | 0x20 | 0x00 | 0x01 = 0xE1
+    # ID: 5850 = 0x16da
+    # Value: 0x01
+    buf = unhexlify('e116da01')
+    tlv = LWM2M_TLV(buf)
+    assert tlv.type == LWM2M_TLV_RESOURCE
+    assert tlv.id == 5850
+    assert tlv.value == b'\x01'
+    assert bytes(tlv) == buf
+
+    # Multiple resources example
+    # Resource 0 (Manufacturer): "Open Mobile Alliance"
+    # Type: 11, ID len 0 (8-bit), Len type 01 (8-bit), Val len 20
+    # 0xC0 | 0x00 | 0x08 | 0x00 = 0xC8
+    buf2 = unhexlify('c800144f70656e204d6f62696c6520416c6c69616e6365')
+    tlv2 = LWM2M_TLV(buf2)
+    assert tlv2.id == 0
+    assert tlv2.value == b'Open Mobile Alliance'
+    assert bytes(tlv2) == buf2
+
+    # Test parse_tlvs
+    combined = buf + buf2
+    tlvs = parse_tlvs(combined)
+    assert len(tlvs) == 2
+    assert tlvs[0].id == 5850
+    assert tlvs[1].id == 0
+
+
+if __name__ == '__main__':
+    test_lwm2m()
+    print('Tests passed.')

--- a/examples/leshan_agent.py
+++ b/examples/leshan_agent.py
@@ -29,10 +29,20 @@ def encode_float(val):
     """Encode float to LWM2M binary format (4 or 8 bytes IEEE 754)."""
     return struct.pack('>f', val) # 4-byte float
 
+def default_bind_host(server_host, server_port):
+    probe = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        probe.connect((server_host, server_port))
+        return probe.getsockname()[0]
+    except OSError:
+        return '127.0.0.1'
+    finally:
+        probe.close()
+
 def run_leshan_agent():
-    BIND_HOST = os.environ.get('LWM2M_BIND_HOST', '127.0.0.1')
     SERVER_HOST = os.environ.get('LESHAN_HOST', 'leshan.eclipseprojects.io')
     SERVER_PORT = 5683
+    BIND_HOST = os.environ.get('LWM2M_BIND_HOST', default_bind_host(SERVER_HOST, SERVER_PORT))
     ENDPOINT = 'dpkt-agent-2026'
     
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)

--- a/examples/leshan_agent.py
+++ b/examples/leshan_agent.py
@@ -5,29 +5,7 @@ import dpkt
 import struct
 import time
 import select
-
-def encode_int(val):
-    """Encode integer to LWM2M binary format (1, 2, 4, or 8 bytes)."""
-    if -128 <= val <= 127:
-        return struct.pack('b', val)
-    elif -32768 <= val <= 32767:
-        return struct.pack('>h', val)
-    elif -2147483648 <= val <= 2147483647:
-        return struct.pack('>i', val)
-    else:
-        return struct.pack('>q', val)
-
-def decode_int(val):
-    """Decode LWM2M binary integer."""
-    if len(val) == 1: return struct.unpack('b', val)[0]
-    if len(val) == 2: return struct.unpack('>h', val)[0]
-    if len(val) == 4: return struct.unpack('>i', val)[0]
-    if len(val) == 8: return struct.unpack('>q', val)[0]
-    return 0
-
-def encode_float(val):
-    """Encode float to LWM2M binary format (4 or 8 bytes IEEE 754)."""
-    return struct.pack('>f', val) # 4-byte float
+from dpkt.lwm2m import LWM2M
 
 def default_bind_host(server_host, server_port):
     probe = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -91,72 +69,72 @@ def run_leshan_agent():
                     
                     if req.code == dpkt.coap.COAP_GET:
                         print(f"[*] Received CoAP GET {path_str} (Accept={accept})")
-                        
-                        resp_data = b''
-                        content_format = dpkt.coap.COAP_FORMAT_LWM2M_TLV
-                        
-                        # Route by Object ID
+
+                        # Route by Object ID — build resources as native Python
+                        # values; LWM2M.encode handles TLV/JSON serialization.
                         obj_id = int(paths[0])
-                        
-                        if obj_id == 3: # Device
-                            resources = {
-                                0: (b'dpkt-project', 'string'), 1: (b'cli-agent-v1.2', 'string'),
-                                2: (b'SN-2026-DPKT', 'string'), 3: (b'1.9.8', 'string'),
-                                6: (encode_int(1), 'multiple_int'), 7: (encode_int(3800), 'multiple_int'),
-                                9: (encode_int(95), 'int'), 10: (encode_int(1024), 'int'),
-                                13: (encode_int(int(time.time())), 'int'), 14: (b'+01:00', 'string'),
-                                15: (b'Europe/Stockholm', 'string'), 17: (b'DPKT-Map-Agent', 'string'),
-                                18: (b'v1.0-virtual', 'string'), 20: (encode_int(1), 'int'), 21: (encode_int(2048), 'int'),
-                            }
-                        elif obj_id == 6: # Location
-                            resources = {
-                                0: (encode_float(59.3293), 'float'), # Latitude (Stockholm)
-                                1: (encode_float(18.0686), 'float'), # Longitude
-                                2: (encode_float(15.0), 'float'),    # Altitude
-                                5: (encode_int(int(time.time())), 'int') # Timestamp
-                            }
-                        elif obj_id == 3303: # Temperature
-                            resources = {
-                                5700: (encode_float(21.5), 'float'), # Sensor Value
-                                5701: (b'Cel', 'string')             # Units
-                            }
+                        if obj_id == 3:  # Device
+                            resources = [
+                                LWM2M.Resource(0,  'dpkt-project'),
+                                LWM2M.Resource(1,  'cli-agent-v1.2'),
+                                LWM2M.Resource(2,  'SN-2026-DPKT'),
+                                LWM2M.Resource(3,  '1.9.8'),
+                                LWM2M.Resource(6,  instances={0: 1}),
+                                LWM2M.Resource(7,  instances={0: 3800}),
+                                LWM2M.Resource(9,  95),
+                                LWM2M.Resource(10, 1024),
+                                LWM2M.Resource(13, int(time.time())),
+                                LWM2M.Resource(14, '+01:00'),
+                                LWM2M.Resource(15, 'Europe/Stockholm'),
+                                LWM2M.Resource(17, 'DPKT-Map-Agent'),
+                                LWM2M.Resource(18, 'v1.0-virtual'),
+                                LWM2M.Resource(20, 1),
+                                LWM2M.Resource(21, 2048),
+                            ]
+                        elif obj_id == 6:  # Location (Stockholm)
+                            resources = [
+                                LWM2M.Resource(0, 59.3293),
+                                LWM2M.Resource(1, 18.0686),
+                                LWM2M.Resource(2, 15.0),
+                                LWM2M.Resource(5, int(time.time())),
+                            ]
+                        elif obj_id == 3303:  # Temperature
+                            resources = [
+                                LWM2M.Resource(5700, 21.5),
+                                LWM2M.Resource(5701, 'Cel'),
+                            ]
                         else:
-                            resources = {}
+                            resources = []
 
                         if not resources:
                             resp = dpkt.coap.CoAP(t=dpkt.coap.COAP_ACK, code=dpkt.coap.COAP_NOT_FOUND, id=req.id, token=req.token)
                             sock.sendto(bytes(resp), addr)
                             continue
 
-                        # Resource or Object response
+                        # Decide what to return: a single Resource (deep path)
+                        # or the whole ObjectInstance (shorter path).
                         if len(paths) >= 3:
                             res_id = int(paths[-1])
-                            if res_id in resources:
-                                val, rtype = resources[res_id]
-                                if (accept == 0 or accept is None) and rtype in ['string', 'int']:
-                                    resp_data = val if rtype == 'string' else str(decode_int(val)).encode()
-                                    content_format = dpkt.coap.COAP_FORMAT_TEXT
-                                else:
-                                    tlv_type = dpkt.lwm2m.LWM2M_TLV_MULTIPLE_RESOURCE if rtype == 'multiple_int' else dpkt.lwm2m.LWM2M_TLV_RESOURCE
-                                    if rtype == 'multiple_int':
-                                        val = bytes(dpkt.lwm2m.LWM2M_TLV(type=dpkt.lwm2m.LWM2M_TLV_RESOURCE_INSTANCE, id=0, value=val))
-                                    tlv = dpkt.lwm2m.LWM2M_TLV(type=tlv_type, id=res_id, value=val)
-                                    resp_data = bytes(tlv)
-                            else:
+                            target = next((r for r in resources if r.id == res_id), None)
+                            if target is None:
                                 resp = dpkt.coap.CoAP(t=dpkt.coap.COAP_ACK, code=dpkt.coap.COAP_NOT_FOUND, id=req.id, token=req.token)
                                 sock.sendto(bytes(resp), addr)
                                 continue
-                        else: # Instance or Object read
-                            tlvs = []
-                            for rid in sorted(resources.keys()):
-                                val, rtype = resources[rid]
-                                if rtype == 'multiple_int':
-                                    inst = dpkt.lwm2m.LWM2M_TLV(type=dpkt.lwm2m.LWM2M_TLV_RESOURCE_INSTANCE, id=0, value=val)
-                                    tlvs.append(dpkt.lwm2m.LWM2M_TLV(type=dpkt.lwm2m.LWM2M_TLV_MULTIPLE_RESOURCE, id=rid, value=bytes(inst)))
-                                else:
-                                    tlvs.append(dpkt.lwm2m.LWM2M_TLV(type=dpkt.lwm2m.LWM2M_TLV_RESOURCE, id=rid, value=val))
-                            obj_inst = dpkt.lwm2m.LWM2M_TLV(type=dpkt.lwm2m.LWM2M_TLV_OBJECT_INSTANCE, id=0, value=b''.join(bytes(t) for t in tlvs))
-                            resp_data = bytes(obj_inst)
+                        else:
+                            inst_id = int(paths[1]) if len(paths) > 1 else 0
+                            target = LWM2M.ObjectInstance(id=inst_id, resources=resources)
+
+                        # Pick wire format based on Accept.
+                        single_simple = (isinstance(target, LWM2M.Resource)
+                                         and not target.is_multi
+                                         and isinstance(target.value, (str, int))
+                                         and not isinstance(target.value, bool))
+                        if (accept in (0, None)) and single_simple:
+                            resp_data = str(target.value).encode('utf-8')
+                            content_format = dpkt.coap.COAP_FORMAT_TEXT
+                        else:
+                            resp_data = LWM2M.encode(target, LWM2M.ContentFormat.TLV)
+                            content_format = dpkt.coap.COAP_FORMAT_LWM2M_TLV
 
                         resp = dpkt.coap.CoAP(t=dpkt.coap.COAP_ACK, code=dpkt.coap.COAP_CONTENT, id=req.id, token=req.token, data=resp_data)
                         fmt_val = struct.pack('>H', content_format) if content_format > 255 else struct.pack('B', content_format)

--- a/examples/leshan_agent.py
+++ b/examples/leshan_agent.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python
+import socket
+import dpkt
+import struct
+import time
+import select
+
+def encode_int(val):
+    """Encode integer to LWM2M binary format (1, 2, 4, or 8 bytes)."""
+    if -128 <= val <= 127:
+        return struct.pack('b', val)
+    elif -32768 <= val <= 32767:
+        return struct.pack('>h', val)
+    elif -2147483648 <= val <= 2147483647:
+        return struct.pack('>i', val)
+    else:
+        return struct.pack('>q', val)
+
+def decode_int(val):
+    """Decode LWM2M binary integer."""
+    if len(val) == 1: return struct.unpack('b', val)[0]
+    if len(val) == 2: return struct.unpack('>h', val)[0]
+    if len(val) == 4: return struct.unpack('>i', val)[0]
+    if len(val) == 8: return struct.unpack('>q', val)[0]
+    return 0
+
+def encode_float(val):
+    """Encode float to LWM2M binary format (4 or 8 bytes IEEE 754)."""
+    return struct.pack('>f', val) # 4-byte float
+
+def run_leshan_agent():
+    SERVER_IP = '23.97.187.154'
+    SERVER_PORT = 5683
+    ENDPOINT = 'dpkt-agent-2026'
+    
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.bind(('0.0.0.0', 5685))
+    sock.setblocking(0)
+
+    def send_reg(is_update=False):
+        # Register Object 3 (Device), 6 (Location), and 3303 (Temperature)
+        reg = dpkt.coap.CoAP(
+            t=dpkt.coap.COAP_CON,
+            code=dpkt.coap.COAP_POST,
+            id=int(time.time()) & 0xFFFF,
+            token=b'\xaa\xbb',
+            data=b'</3/0>,</6/0>,</3303/0>' if not is_update else b''
+        )
+        reg.opts.append((dpkt.coap.COAP_OPT_URI_PATH, b'rd'))
+        reg.opts.append((dpkt.coap.COAP_OPT_URI_QUERY, f"ep={ENDPOINT}".encode()))
+        reg.opts.append((dpkt.coap.COAP_OPT_URI_QUERY, b"lwm2m=1.0"))
+        reg.opts.append((dpkt.coap.COAP_OPT_URI_QUERY, b"lt=86400"))
+        reg.opts.append((dpkt.coap.COAP_OPT_URI_QUERY, b"b=U"))
+        reg.opts.append((dpkt.coap.COAP_OPT_CONTENT_FORMAT, struct.pack('B', dpkt.coap.COAP_FORMAT_LINK)))
+        sock.sendto(bytes(reg), (SERVER_IP, SERVER_PORT))
+        print(f"[*] Sent {'Update' if is_update else 'Registration'} for {ENDPOINT}")
+
+    send_reg()
+    last_update = time.time()
+    
+    try:
+        while True:
+            ready = select.select([sock], [], [], 1.0)
+            if ready[0]:
+                data, addr = sock.recvfrom(2048)
+                try:
+                    req = dpkt.coap.CoAP(data)
+                    paths = []
+                    accept = None
+                    for opt_num, opt_val in req.opts:
+                        if opt_num == dpkt.coap.COAP_OPT_URI_PATH:
+                            paths.append(opt_val.decode())
+                        if opt_num == dpkt.coap.COAP_OPT_ACCEPT:
+                            if not opt_val: accept = 0
+                            elif len(opt_val) == 1: accept = struct.unpack('B', opt_val)[0]
+                            elif len(opt_val) == 2: accept = struct.unpack('>H', opt_val)[0]
+
+                    path_str = "/" + "/".join(paths)
+                    
+                    if req.code == dpkt.coap.COAP_GET:
+                        print(f"[*] Received CoAP GET {path_str} (Accept={accept})")
+                        
+                        resp_data = b''
+                        content_format = dpkt.coap.COAP_FORMAT_LWM2M_TLV
+                        
+                        # Route by Object ID
+                        obj_id = int(paths[0])
+                        
+                        if obj_id == 3: # Device
+                            resources = {
+                                0: (b'dpkt-project', 'string'), 1: (b'cli-agent-v1.2', 'string'),
+                                2: (b'SN-2026-DPKT', 'string'), 3: (b'1.9.8', 'string'),
+                                6: (encode_int(1), 'multiple_int'), 7: (encode_int(3800), 'multiple_int'),
+                                9: (encode_int(95), 'int'), 10: (encode_int(1024), 'int'),
+                                13: (encode_int(int(time.time())), 'int'), 14: (b'+01:00', 'string'),
+                                15: (b'Europe/Stockholm', 'string'), 17: (b'DPKT-Map-Agent', 'string'),
+                                18: (b'v1.0-virtual', 'string'), 20: (encode_int(1), 'int'), 21: (encode_int(2048), 'int'),
+                            }
+                        elif obj_id == 6: # Location
+                            resources = {
+                                0: (encode_float(59.3293), 'float'), # Latitude (Stockholm)
+                                1: (encode_float(18.0686), 'float'), # Longitude
+                                2: (encode_float(15.0), 'float'),    # Altitude
+                                5: (encode_int(int(time.time())), 'int') # Timestamp
+                            }
+                        elif obj_id == 3303: # Temperature
+                            resources = {
+                                5700: (encode_float(21.5), 'float'), # Sensor Value
+                                5701: (b'Cel', 'string')             # Units
+                            }
+                        else:
+                            resources = {}
+
+                        if not resources:
+                            resp = dpkt.coap.CoAP(t=dpkt.coap.COAP_ACK, code=dpkt.coap.COAP_NOT_FOUND, id=req.id, token=req.token)
+                            sock.sendto(bytes(resp), addr)
+                            continue
+
+                        # Resource or Object response
+                        if len(paths) >= 3:
+                            res_id = int(paths[-1])
+                            if res_id in resources:
+                                val, rtype = resources[res_id]
+                                if (accept == 0 or accept is None) and rtype in ['string', 'int']:
+                                    resp_data = val if rtype == 'string' else str(decode_int(val)).encode()
+                                    content_format = dpkt.coap.COAP_FORMAT_TEXT
+                                else:
+                                    tlv_type = dpkt.lwm2m.LWM2M_TLV_MULTIPLE_RESOURCE if rtype == 'multiple_int' else dpkt.lwm2m.LWM2M_TLV_RESOURCE
+                                    if rtype == 'multiple_int':
+                                        val = bytes(dpkt.lwm2m.LWM2M_TLV(type=dpkt.lwm2m.LWM2M_TLV_RESOURCE_INSTANCE, id=0, value=val))
+                                    tlv = dpkt.lwm2m.LWM2M_TLV(type=tlv_type, id=res_id, value=val)
+                                    resp_data = bytes(tlv)
+                            else:
+                                resp = dpkt.coap.CoAP(t=dpkt.coap.COAP_ACK, code=dpkt.coap.COAP_NOT_FOUND, id=req.id, token=req.token)
+                                sock.sendto(bytes(resp), addr)
+                                continue
+                        else: # Instance or Object read
+                            tlvs = []
+                            for rid in sorted(resources.keys()):
+                                val, rtype = resources[rid]
+                                if rtype == 'multiple_int':
+                                    inst = dpkt.lwm2m.LWM2M_TLV(type=dpkt.lwm2m.LWM2M_TLV_RESOURCE_INSTANCE, id=0, value=val)
+                                    tlvs.append(dpkt.lwm2m.LWM2M_TLV(type=dpkt.lwm2m.LWM2M_TLV_MULTIPLE_RESOURCE, id=rid, value=bytes(inst)))
+                                else:
+                                    tlvs.append(dpkt.lwm2m.LWM2M_TLV(type=dpkt.lwm2m.LWM2M_TLV_RESOURCE, id=rid, value=val))
+                            obj_inst = dpkt.lwm2m.LWM2M_TLV(type=dpkt.lwm2m.LWM2M_TLV_OBJECT_INSTANCE, id=0, value=b''.join(bytes(t) for t in tlvs))
+                            resp_data = bytes(obj_inst)
+
+                        resp = dpkt.coap.CoAP(t=dpkt.coap.COAP_ACK, code=dpkt.coap.COAP_CONTENT, id=req.id, token=req.token, data=resp_data)
+                        fmt_val = struct.pack('>H', content_format) if content_format > 255 else struct.pack('B', content_format)
+                        resp.opts.append((dpkt.coap.COAP_OPT_CONTENT_FORMAT, fmt_val))
+                        sock.sendto(bytes(resp), addr)
+                        print(f"    [+] Responded {path_str} (format {content_format})")
+                except Exception as e:
+                    print(f"[!] Error: {e}")
+
+            if time.time() - last_update > 60:
+                send_reg(is_update=True)
+                last_update = time.time()
+
+    except KeyboardInterrupt: pass
+    finally: sock.close()
+
+if __name__ == "__main__":
+    run_leshan_agent()

--- a/examples/leshan_agent.py
+++ b/examples/leshan_agent.py
@@ -129,7 +129,11 @@ def run_leshan_agent():
                                          and not target.is_multi
                                          and isinstance(target.value, (str, int))
                                          and not isinstance(target.value, bool))
-                        if (accept in (0, None)) and single_simple:
+                        if accept == dpkt.coap.COAP_FORMAT_LWM2M_JSON:
+                            base_path = f'/{obj_id}/{paths[1] if len(paths) > 1 else 0}/'
+                            resp_data = LWM2M.encode(target, LWM2M.ContentFormat.JSON, base_path=base_path)
+                            content_format = dpkt.coap.COAP_FORMAT_LWM2M_JSON
+                        elif (accept in (0, None)) and single_simple:
                             resp_data = str(target.value).encode('utf-8')
                             content_format = dpkt.coap.COAP_FORMAT_TEXT
                         else:

--- a/examples/leshan_agent.py
+++ b/examples/leshan_agent.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import os
 import socket
 import dpkt
 import struct
@@ -29,12 +30,13 @@ def encode_float(val):
     return struct.pack('>f', val) # 4-byte float
 
 def run_leshan_agent():
-    SERVER_IP = '23.97.187.154'
+    BIND_HOST = os.environ.get('LWM2M_BIND_HOST', '127.0.0.1')
+    SERVER_HOST = os.environ.get('LESHAN_HOST', 'leshan.eclipseprojects.io')
     SERVER_PORT = 5683
     ENDPOINT = 'dpkt-agent-2026'
     
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    sock.bind(('0.0.0.0', 5685))
+    sock.bind((BIND_HOST, 5685))
     sock.setblocking(0)
 
     def send_reg(is_update=False):
@@ -52,7 +54,7 @@ def run_leshan_agent():
         reg.opts.append((dpkt.coap.COAP_OPT_URI_QUERY, b"lt=86400"))
         reg.opts.append((dpkt.coap.COAP_OPT_URI_QUERY, b"b=U"))
         reg.opts.append((dpkt.coap.COAP_OPT_CONTENT_FORMAT, struct.pack('B', dpkt.coap.COAP_FORMAT_LINK)))
-        sock.sendto(bytes(reg), (SERVER_IP, SERVER_PORT))
+        sock.sendto(bytes(reg), (SERVER_HOST, SERVER_PORT))
         print(f"[*] Sent {'Update' if is_update else 'Registration'} for {ENDPOINT}")
 
     send_reg()

--- a/examples/lwm2m_device.py
+++ b/examples/lwm2m_device.py
@@ -51,20 +51,18 @@ def run_device():
         # Note: In a real client we'd parse opts properly
         print(f"[*] Received request from {addr}: Code={req.code}")
         
-        # 3. Respond with LWM2M TLV data
-        # Device Manufacturer (Resource ID 0)
-        tlv = dpkt.lwm2m.LWM2M_TLV(
-            type=dpkt.lwm2m.LWM2M_TLV_RESOURCE,
-            id=dpkt.lwm2m.LWM2M_DEV_MANUFACTURER,
-            value=b'dpkt-project'
-        )
-        
+        # 3. Respond with LWM2M TLV data via the format-agnostic data model.
+        from dpkt.lwm2m import LWM2M
+        manufacturer = LWM2M.Resource(id=dpkt.lwm2m.LWM2M_DEV_MANUFACTURER,
+                                      value='dpkt-project')
+        payload = LWM2M.encode(manufacturer, LWM2M.ContentFormat.TLV)
+
         resp = dpkt.coap.CoAP(
             t=dpkt.coap.COAP_ACK,
             code=dpkt.coap.COAP_CONTENT,
             id=req.id,
             token=req.token,
-            data=bytes(tlv)
+            data=payload
         )
         resp.opts.append((dpkt.coap.COAP_OPT_CONTENT_FORMAT, struct.pack('>H', dpkt.coap.COAP_FORMAT_LWM2M_TLV)))
         

--- a/examples/lwm2m_device.py
+++ b/examples/lwm2m_device.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+"""
+LWM2M Device Example
+Simulates an LWM2M Client that registers and responds to Read requests.
+"""
+import socket
+import dpkt
+
+def run_device():
+    # Configuration
+    SERVER_IP = '127.0.0.1'
+    SERVER_PORT = 5683
+    DEVICE_PORT = 5684
+    ENDPOINT = 'dpkt-device'
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.bind(('0.0.0.0', DEVICE_PORT))
+    sock.settimeout(5.0)
+
+    print(f"[*] LWM2M Device '{ENDPOINT}' started on port {DEVICE_PORT}")
+
+    # 1. Build Registration Request
+    # POST /rd?ep=dpkt-device
+    # Payload: </3> (Indicates Device Object is available)
+    reg = dpkt.coap.CoAP(
+        t=dpkt.coap.COAP_CON,
+        code=dpkt.coap.COAP_POST,
+        id=1,
+        token=b'\xde\xad',
+        data=b'</3>'
+    )
+    # Adding URI-Path: "rd"
+    reg.opts.append((dpkt.coap.COAP_OPT_URI_PATH, b'rd'))
+    # Adding URI-Query: "ep=dpkt-device"
+    reg.opts.append((dpkt.coap.COAP_OPT_URI_QUERY, f"ep={ENDPOINT}".encode()))
+    # Content-Format: application/link-format (40)
+    reg.opts.append((dpkt.coap.COAP_OPT_CONTENT_FORMAT, struct.pack('B', dpkt.coap.COAP_FORMAT_LINK)))
+
+    
+    print(f"[*] Sending Registration to {SERVER_IP}:{SERVER_PORT}...")
+    sock.sendto(bytes(reg), (SERVER_IP, SERVER_PORT))
+
+    try:
+        # 2. Wait for Read Request from Server
+        data, addr = sock.recvfrom(1024)
+        req = dpkt.coap.CoAP(data)
+        
+        # Check if it's a GET request for Device Manufacturer (/3/0/0)
+        # Note: In a real client we'd parse opts properly
+        print(f"[*] Received request from {addr}: Code={req.code}")
+        
+        # 3. Respond with LWM2M TLV data
+        # Device Manufacturer (Resource ID 0)
+        tlv = dpkt.lwm2m.LWM2M_TLV(
+            type=dpkt.lwm2m.LWM2M_TLV_RESOURCE,
+            id=dpkt.lwm2m.LWM2M_DEV_MANUFACTURER,
+            value=b'dpkt-project'
+        )
+        
+        resp = dpkt.coap.CoAP(
+            t=dpkt.coap.COAP_ACK,
+            code=dpkt.coap.COAP_CONTENT,
+            id=req.id,
+            token=req.token,
+            data=bytes(tlv)
+        )
+        resp.opts.append((dpkt.coap.COAP_OPT_CONTENT_FORMAT, struct.pack('>H', dpkt.coap.COAP_FORMAT_LWM2M_TLV)))
+        
+        print(f"[*] Sending Response: Manufacturer='dpkt-project'")
+        sock.sendto(bytes(resp), addr)
+
+    except socket.timeout:
+        print("[!] No request received from server.")
+    finally:
+        sock.close()
+
+if __name__ == "__main__":
+    import struct
+    run_device()

--- a/examples/lwm2m_device.py
+++ b/examples/lwm2m_device.py
@@ -3,18 +3,20 @@
 LWM2M Device Example
 Simulates an LWM2M Client that registers and responds to Read requests.
 """
+import os
 import socket
 import dpkt
 
 def run_device():
     # Configuration
-    SERVER_IP = '127.0.0.1'
+    BIND_HOST = os.environ.get('LWM2M_BIND_HOST', '127.0.0.1')
+    SERVER_HOST = '127.0.0.1'
     SERVER_PORT = 5683
     DEVICE_PORT = 5684
     ENDPOINT = 'dpkt-device'
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    sock.bind(('0.0.0.0', DEVICE_PORT))
+    sock.bind((BIND_HOST, DEVICE_PORT))
     sock.settimeout(5.0)
 
     print(f"[*] LWM2M Device '{ENDPOINT}' started on port {DEVICE_PORT}")
@@ -37,8 +39,8 @@ def run_device():
     reg.opts.append((dpkt.coap.COAP_OPT_CONTENT_FORMAT, struct.pack('B', dpkt.coap.COAP_FORMAT_LINK)))
 
     
-    print(f"[*] Sending Registration to {SERVER_IP}:{SERVER_PORT}...")
-    sock.sendto(bytes(reg), (SERVER_IP, SERVER_PORT))
+    print(f"[*] Sending Registration to {SERVER_HOST}:{SERVER_PORT}...")
+    sock.sendto(bytes(reg), (SERVER_HOST, SERVER_PORT))
 
     try:
         # 2. Wait for Read Request from Server

--- a/examples/lwm2m_server.py
+++ b/examples/lwm2m_server.py
@@ -3,15 +3,17 @@
 LWM2M Server Example
 Listens for Registration and sends a Read request.
 """
+import os
 import socket
 import dpkt
 
 def run_server():
     # Configuration
+    BIND_HOST = os.environ.get('LWM2M_BIND_HOST', '127.0.0.1')
     SERVER_PORT = 5683
 
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    sock.bind(('0.0.0.0', SERVER_PORT))
+    sock.bind((BIND_HOST, SERVER_PORT))
     sock.settimeout(10.0)
 
     print(f"[*] LWM2M Server started on port {SERVER_PORT}")

--- a/examples/lwm2m_server.py
+++ b/examples/lwm2m_server.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+"""
+LWM2M Server Example
+Listens for Registration and sends a Read request.
+"""
+import socket
+import dpkt
+
+def run_server():
+    # Configuration
+    SERVER_PORT = 5683
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.bind(('0.0.0.0', SERVER_PORT))
+    sock.settimeout(10.0)
+
+    print(f"[*] LWM2M Server started on port {SERVER_PORT}")
+
+    try:
+        # 1. Wait for Registration
+        print("[*] Waiting for Registration...")
+        data, addr = sock.recvfrom(1024)
+        reg = dpkt.coap.CoAP(data)
+        
+        # Extract Endpoint (ep) from URI-Query
+        endpoint = "unknown"
+        for opt_num, opt_val in reg.opts:
+            if opt_num == dpkt.coap.COAP_OPT_URI_QUERY:
+                if b"ep=" in opt_val:
+                    endpoint = opt_val.decode().split('=')[1]
+        
+        print(f"[*] Received Registration from {addr}: '{endpoint}'")
+        if reg.data:
+            print(f"    [+] Supported Objects: {reg.data.decode()}")
+
+        # 2. Send Read Request: GET /3/0/0 (Device Manufacturer)
+        read_req = dpkt.coap.CoAP(
+            t=dpkt.coap.COAP_CON,
+            code=dpkt.coap.COAP_GET,
+            id=42,
+            token=b'\x01\x02\x03\x04'
+        )
+        # Adding URI-Path: "3", "0", "0"
+        read_req.opts.append((dpkt.coap.COAP_OPT_URI_PATH, b'3'))
+        read_req.opts.append((dpkt.coap.COAP_OPT_URI_PATH, b'0'))
+        read_req.opts.append((dpkt.coap.COAP_OPT_URI_PATH, b'0'))
+        
+        print(f"[*] Sending Read request for /3/0/0 to {endpoint}...")
+        sock.sendto(bytes(read_req), addr)
+
+        # 3. Receive Read Response
+        data, addr = sock.recvfrom(1024)
+        resp = dpkt.coap.CoAP(data)
+        
+        print(f"[*] Received Read Response: Code={resp.code}")
+        
+        # 4. Parse LWM2M TLV data
+        tlvs = dpkt.lwm2m.parse_tlvs(resp.data)
+        for tlv in tlvs:
+            if tlv.id == dpkt.lwm2m.LWM2M_DEV_MANUFACTURER:
+                print(f"    [+] Resource ID {tlv.id} (Manufacturer): {tlv.value.decode()}")
+            else:
+                print(f"    [+] Resource ID {tlv.id}: {tlv.value}")
+
+    except socket.timeout:
+        print("[!] Timeout: No messages received.")
+    finally:
+        sock.close()
+
+if __name__ == "__main__":
+    run_server()

--- a/examples/lwm2m_server.py
+++ b/examples/lwm2m_server.py
@@ -56,13 +56,19 @@ def run_server():
         
         print(f"[*] Received Read Response: Code={resp.code}")
         
-        # 4. Parse LWM2M TLV data
-        tlvs = dpkt.lwm2m.parse_tlvs(resp.data)
-        for tlv in tlvs:
-            if tlv.id == dpkt.lwm2m.LWM2M_DEV_MANUFACTURER:
-                print(f"    [+] Resource ID {tlv.id} (Manufacturer): {tlv.value.decode()}")
+        # 4. Parse LWM2M TLV data via the format-agnostic decoder.
+        from dpkt.lwm2m import LWM2M
+        decoded = LWM2M.decode(resp.data, LWM2M.ContentFormat.TLV)
+        # decode() returns a single Resource for a one-resource payload,
+        # or an ObjectInstance / list for richer responses.
+        resources = (decoded.resources if isinstance(decoded, LWM2M.ObjectInstance)
+                     else [decoded] if isinstance(decoded, LWM2M.Resource)
+                     else decoded)
+        for r in resources:
+            if r.id == dpkt.lwm2m.LWM2M_DEV_MANUFACTURER:
+                print(f"    [+] Resource ID {r.id} (Manufacturer): {r.value.decode()}")
             else:
-                print(f"    [+] Resource ID {tlv.id}: {tlv.value}")
+                print(f"    [+] Resource ID {r.id}: {r.value}")
 
     except socket.timeout:
         print("[!] Timeout: No messages received.")


### PR DESCRIPTION
Implement CoAP (RFC 7252) with support for core features, Observe (RFC 7641), and Block-wise transfers (RFC 7959).
Implement LWM2M Binary TLV + JSON (OMA LWM2M v1.0) with support for Object Instances, Multiple Resources, and Resource Instances.
Add functional examples for LWM2M devices and servers, including a Leshan-ready agent.
